### PR TITLE
feat(ISCCSubmit): 新增 iscc session/nonce 命令及每日自动刷新 session

### DIFF
--- a/app/modules/ISCCSubmit/__init__.py
+++ b/app/modules/ISCCSubmit/__init__.py
@@ -12,11 +12,19 @@ os.makedirs(DATA_DIR, exist_ok=True)
 BASE_URL = "https://iscc.isclab.org.cn"
 CONFIG_COMMAND = "iscc配置"
 HELP_COMMAND = "iscc帮助"
+SESSION_COMMAND = "isccsession"
+NONCE_COMMAND = "isccnonce"
 FLAG_PATTERN = r"^ISCC\{.+\}$"
+
+# 每日自动刷新 session 的北京时间（24 小时制）
+DAILY_REFRESH_HOUR = 7
+DAILY_REFRESH_MINUTE = 50
 
 COMMANDS = {
     SWITCH_NAME: "系统管理员开关 ISCC 自动提交模块",
     CONFIG_COMMAND: "配置 ISCC 账号，用法：iscc配置 <账号> <密码>",
     "ISCC{xxxxx}": "提交 flag 到 ISCC 平台未解题目",
+    SESSION_COMMAND: "查询当前 ISCC session",
+    NONCE_COMMAND: "查询当前 ISCC 练武题和擂台题 nonce",
     HELP_COMMAND: "查看 ISCC 自动提交帮助",
 }

--- a/app/modules/ISCCSubmit/handlers/data_manager.py
+++ b/app/modules/ISCCSubmit/handlers/data_manager.py
@@ -37,6 +37,16 @@ class DataManager:
             )
             """
         )
+        # 通用 k/v 元数据表，用于持久化跨进程状态（例如每日刷新日期）
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS iscc_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
         self.conn.commit()
 
     def __enter__(self):
@@ -130,3 +140,25 @@ class DataManager:
         new_regular = regular_nonce if regular_nonce is not None else existing.get("regular_nonce", "")
         new_arena = arena_nonce if arena_nonce is not None else existing.get("arena_nonce", "")
         self.save_nonce(user_id, new_regular, new_arena)
+
+    def get_meta(self, key: str) -> str:
+        self.cursor.execute(
+            """
+            SELECT value FROM iscc_meta WHERE key = ?
+            """,
+            (key,),
+        )
+        row = self.cursor.fetchone()
+        return row["value"] if row else ""
+
+    def set_meta(self, key: str, value: str):
+        self.cursor.execute(
+            """
+            INSERT INTO iscc_meta (key, value, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(key)
+            DO UPDATE SET value = excluded.value,
+                          updated_at = excluded.updated_at
+            """,
+            (key, value, self._now_text()),
+        )

--- a/app/modules/ISCCSubmit/handlers/data_manager.py
+++ b/app/modules/ISCCSubmit/handlers/data_manager.py
@@ -27,6 +27,16 @@ class DataManager:
             )
             """
         )
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS iscc_nonce (
+                user_id TEXT PRIMARY KEY,
+                regular_nonce TEXT NOT NULL DEFAULT '',
+                arena_nonce TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
         self.conn.commit()
 
     def __enter__(self):
@@ -88,3 +98,35 @@ class DataManager:
             """,
             (session, self._now_text(), user_id),
         )
+
+    def get_nonce(self, user_id: str) -> dict | None:
+        self.cursor.execute(
+            """
+            SELECT user_id, regular_nonce, arena_nonce, updated_at FROM iscc_nonce
+            WHERE user_id = ?
+            """,
+            (user_id,),
+        )
+        row = self.cursor.fetchone()
+        return dict(row) if row else None
+
+    def save_nonce(self, user_id: str, regular_nonce: str = "", arena_nonce: str = ""):
+        """保存 nonce，传入的空字符串会覆盖已有值，因此调用方需按需传入。"""
+        self.cursor.execute(
+            """
+            INSERT INTO iscc_nonce (user_id, regular_nonce, arena_nonce, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(user_id)
+            DO UPDATE SET regular_nonce = excluded.regular_nonce,
+                          arena_nonce = excluded.arena_nonce,
+                          updated_at = excluded.updated_at
+            """,
+            (user_id, regular_nonce, arena_nonce, self._now_text()),
+        )
+
+    def update_nonce(self, user_id: str, regular_nonce: str | None = None, arena_nonce: str | None = None):
+        """按需更新单一 nonce 字段，None 表示保持原值。"""
+        existing = self.get_nonce(user_id) or {"regular_nonce": "", "arena_nonce": ""}
+        new_regular = regular_nonce if regular_nonce is not None else existing.get("regular_nonce", "")
+        new_arena = arena_nonce if arena_nonce is not None else existing.get("arena_nonce", "")
+        self.save_nonce(user_id, new_regular, new_arena)

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -7,7 +7,15 @@ from logger import logger
 from utils.auth import is_system_admin
 from utils.generate import generate_reply_message, generate_text_message
 
-from .. import CONFIG_COMMAND, FLAG_PATTERN, HELP_COMMAND, MODULE_NAME, SWITCH_NAME
+from .. import (
+    CONFIG_COMMAND,
+    FLAG_PATTERN,
+    HELP_COMMAND,
+    MODULE_NAME,
+    NONCE_COMMAND,
+    SESSION_COMMAND,
+    SWITCH_NAME,
+)
 from .data_manager import DataManager
 from .iscc_client import ISCCClient, ISCCClientError, SubmitResult
 
@@ -36,6 +44,12 @@ class PrivateMessageHandler:
 
             if self.raw_message.startswith(f"{CONFIG_COMMAND} "):
                 await self._handle_config()
+                return
+            if self.raw_message.lower() == SESSION_COMMAND.lower():
+                await self._handle_query_session()
+                return
+            if self.raw_message.lower() == NONCE_COMMAND.lower():
+                await self._handle_query_nonce()
                 return
             if re.fullmatch(FLAG_PATTERN, self.raw_message):
                 await self._handle_submit_flag()
@@ -86,7 +100,52 @@ class PrivateMessageHandler:
         client = await self._ensure_client(account)
         results = await client.submit_flag_to_unsolved(self.raw_message)
         await self._save_session(client.session_cookie)
+        await self._refresh_nonces(client)
         await self._reply(self._format_results(results))
+
+    async def _handle_query_session(self):
+        with DataManager() as dm:
+            account = dm.get_account(self.user_id)
+        if not account:
+            await self._reply("尚未配置 ISCC 账号，请先发送：iscc配置 <账号> <密码>")
+            return
+        session = account.get("session") or ""
+        if not session:
+            await self._reply("当前未保存 ISCC session，请提交一次 flag 触发登录。")
+            return
+        await self._reply(f"当前 ISCC session：\n{session}")
+
+    async def _handle_query_nonce(self):
+        with DataManager() as dm:
+            account = dm.get_account(self.user_id)
+            nonce_row = dm.get_nonce(self.user_id) if account else None
+        if not account:
+            await self._reply("尚未配置 ISCC 账号，请先发送：iscc配置 <账号> <密码>")
+            return
+
+        if not nonce_row or (not nonce_row.get("regular_nonce") and not nonce_row.get("arena_nonce")):
+            # 没有缓存的 nonce，尝试立刻拉取一次
+            client = await self._ensure_client(account)
+            regular_nonce, arena_nonce = await client.fetch_nonces()
+            await self._save_session(client.session_cookie)
+            if regular_nonce or arena_nonce:
+                with DataManager() as dm:
+                    dm.save_nonce(self.user_id, regular_nonce, arena_nonce)
+                nonce_row = {
+                    "regular_nonce": regular_nonce,
+                    "arena_nonce": arena_nonce,
+                    "updated_at": "刚刚",
+                }
+            else:
+                await self._reply("获取 nonce 失败，请稍后重试。")
+                return
+
+        await self._reply(
+            "当前 ISCC nonce：\n"
+            f"练武题 nonce：{nonce_row.get('regular_nonce') or '（未获取）'}\n"
+            f"擂台题 nonce：{nonce_row.get('arena_nonce') or '（未获取）'}\n"
+            f"更新时间：{nonce_row.get('updated_at', '未知')}"
+        )
 
     async def _ensure_client(self, account: dict) -> ISCCClient:
         client = ISCCClient(account.get("session", ""))
@@ -103,6 +162,17 @@ class PrivateMessageHandler:
             return
         with DataManager() as dm:
             dm.save_session(self.user_id, session)
+
+    async def _refresh_nonces(self, client: ISCCClient):
+        try:
+            regular_nonce, arena_nonce = await client.fetch_nonces()
+        except Exception as e:
+            logger.warning(f"[{MODULE_NAME}]刷新 nonce 失败: {e}")
+            return
+        if not regular_nonce and not arena_nonce:
+            return
+        with DataManager() as dm:
+            dm.save_nonce(self.user_id, regular_nonce, arena_nonce)
 
     def _format_results(self, results: list[SubmitResult]) -> str:
         if not results:
@@ -128,6 +198,8 @@ class PrivateMessageHandler:
             "iscc：系统管理员开关模块\n"
             "iscc配置 <账号> <密码>：登录并保存账号、密码、session\n"
             "ISCC{xxxxx}：提交 flag 到练武题和擂台题所有未解题目\n"
+            f"{SESSION_COMMAND}：查询当前 ISCC session\n"
+            f"{NONCE_COMMAND}：查询当前练武题和擂台题 nonce\n"
             f"{SWITCH_NAME}{MENU_COMMAND}：查看模块菜单"
         )
 

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -100,7 +100,7 @@ class PrivateMessageHandler:
         client = await self._ensure_client(account)
         results = await client.submit_flag_to_unsolved(self.raw_message)
         await self._save_session(client.session_cookie)
-        await self._refresh_nonces(client)
+        await self._refresh_nonces(client, account)
         await self._reply(self._format_results(results))
 
     async def _handle_query_session(self):
@@ -124,14 +124,21 @@ class PrivateMessageHandler:
             return
 
         if not nonce_row or (not nonce_row.get("regular_nonce") and not nonce_row.get("arena_nonce")):
-            # 没有缓存的 nonce，尝试立刻拉取一次
+            # 没有缓存的 nonce，尝试立刻拉取一次（必要时自动重登录重试）
             client = await self._ensure_client(account)
-            regular_nonce, arena_nonce = await client.fetch_nonces()
+            try:
+                regular_nonce, arena_nonce = await self._fetch_nonces_with_retry(client, account)
+            except ISCCClientError as e:
+                await self._reply(f"获取 nonce 失败：{e}")
+                return
             await self._save_session(client.session_cookie)
             if regular_nonce or arena_nonce:
                 with DataManager() as dm:
-                    dm.save_nonce(self.user_id, regular_nonce, arena_nonce)
-                nonce_row = {
+                    dm.update_nonce(self.user_id, regular_nonce or None, arena_nonce or None)
+                # 为保证回显的 updated_at 与 DB 一致，回读一次；查询不到时退回内存值
+                with DataManager() as dm:
+                    refreshed = dm.get_nonce(self.user_id)
+                nonce_row = refreshed or {
                     "regular_nonce": regular_nonce,
                     "arena_nonce": arena_nonce,
                     "updated_at": "刚刚",
@@ -163,16 +170,37 @@ class PrivateMessageHandler:
         with DataManager() as dm:
             dm.save_session(self.user_id, session)
 
-    async def _refresh_nonces(self, client: ISCCClient):
+    async def _refresh_nonces(self, client: ISCCClient, account: dict):
         try:
-            regular_nonce, arena_nonce = await client.fetch_nonces()
+            regular_nonce, arena_nonce = await self._fetch_nonces_with_retry(client, account)
         except Exception as e:
             logger.warning(f"[{MODULE_NAME}]刷新 nonce 失败: {e}")
             return
         if not regular_nonce and not arena_nonce:
             return
+        # 用 update_nonce + `x or None`：某一路抓到空串时保留 DB 原值，避免被覆盖
         with DataManager() as dm:
-            dm.save_nonce(self.user_id, regular_nonce, arena_nonce)
+            dm.update_nonce(self.user_id, regular_nonce or None, arena_nonce or None)
+
+    async def _fetch_nonces_with_retry(self, client: ISCCClient, account: dict) -> tuple[str, str]:
+        """优先使用当前 session 拉取 nonce；遇到登录失效或两路都空时，重登录后再试一次。"""
+        try:
+            regular_nonce, arena_nonce = await client.fetch_nonces()
+        except ISCCClientError as e:
+            # 登录失效：走重登录后重试一次
+            if "登录状态失效" not in str(e):
+                raise
+            regular_nonce, arena_nonce = "", ""
+
+        if regular_nonce or arena_nonce:
+            return regular_nonce, arena_nonce
+
+        # 两路都拿不到，可能是 session 已失效但页面没把登录表单露出来。
+        # 强制重登录一次再试。
+        session = await client.login(account["username"], account["password"])
+        with DataManager() as dm:
+            dm.save_session(self.user_id, session)
+        return await client.fetch_nonces()
 
     def _format_results(self, results: list[SubmitResult]) -> str:
         if not results:

--- a/app/modules/ISCCSubmit/handlers/handle_meta_event.py
+++ b/app/modules/ISCCSubmit/handlers/handle_meta_event.py
@@ -1,18 +1,24 @@
 import time
+from datetime import datetime, timezone, timedelta
 
 from api.message import send_private_msg
 from core.switchs import is_private_switch_on
 from logger import logger
 from utils.generate import generate_text_message
 
-from .. import MODULE_NAME
+from .. import DAILY_REFRESH_HOUR, DAILY_REFRESH_MINUTE, MODULE_NAME
 from .data_manager import DataManager
 from .iscc_client import ISCCClient
+
+
+BEIJING_TZ = timezone(timedelta(hours=8))
 
 
 class MetaEventHandler:
     _last_run_at = 0
     _running = False
+    # 记录 "YYYY-MM-DD" 字符串，用于保证每个北京时间自然日只刷新一次
+    _last_daily_refresh_date = ""
 
     def __init__(self, websocket, msg):
         self.websocket = websocket
@@ -42,10 +48,32 @@ class MetaEventHandler:
         try:
             with DataManager() as dm:
                 accounts = dm.get_all_accounts()
+
+            beijing_now = datetime.now(BEIJING_TZ)
+            should_daily_refresh = self._should_daily_refresh(beijing_now)
+
             for account in accounts:
-                await self._keep_account_alive(account)
+                if should_daily_refresh:
+                    await self._daily_refresh_account(account, beijing_now)
+                else:
+                    await self._keep_account_alive(account)
+
+            if should_daily_refresh:
+                # 不管账号是否处理成功，都标记当日已触发，避免同一分钟重复执行
+                self.__class__._last_daily_refresh_date = beijing_now.strftime("%Y-%m-%d")
         finally:
             self.__class__._running = False
+
+    def _should_daily_refresh(self, beijing_now: datetime) -> bool:
+        today = beijing_now.strftime("%Y-%m-%d")
+        if self.__class__._last_daily_refresh_date == today:
+            return False
+        # 到达或超过 07:50 即触发。心跳最小间隔 60s，能保证当日被触发。
+        if beijing_now.hour > DAILY_REFRESH_HOUR:
+            return True
+        if beijing_now.hour == DAILY_REFRESH_HOUR and beijing_now.minute >= DAILY_REFRESH_MINUTE:
+            return True
+        return False
 
     async def _keep_account_alive(self, account: dict):
         user_id = str(account["user_id"])
@@ -60,7 +88,66 @@ class MetaEventHandler:
             session = await client.login(account["username"], account["password"])
             with DataManager() as dm:
                 dm.save_session(user_id, session)
-            await send_private_msg(self.websocket, user_id, [generate_text_message("ISCC 登录状态已过期，机器人已自动重新登录并刷新 session。")])
+            await send_private_msg(
+                self.websocket,
+                user_id,
+                [generate_text_message(
+                    "ISCC 登录状态已过期，机器人已自动重新登录并刷新 session。\n"
+                    f"新的 session：{session}"
+                )],
+            )
         except Exception as e:
             logger.error(f"[{MODULE_NAME}]ISCC 自动重新登录失败: {e}")
-            await send_private_msg(self.websocket, user_id, [generate_text_message(f"ISCC 登录状态已过期，自动重新登录失败：{e}")])
+            await send_private_msg(
+                self.websocket,
+                user_id,
+                [generate_text_message(f"ISCC 登录状态已过期，自动重新登录失败：{e}")],
+            )
+
+    async def _daily_refresh_account(self, account: dict, beijing_now: datetime):
+        user_id = str(account["user_id"])
+        username = account.get("username", "")
+        password = account.get("password", "")
+        client = ISCCClient(account.get("session", ""))
+        timestamp = beijing_now.strftime("%Y-%m-%d %H:%M:%S")
+
+        try:
+            session = await client.login(username, password)
+        except Exception as e:
+            logger.error(f"[{MODULE_NAME}]ISCC 每日定时登录失败: {e}")
+            await send_private_msg(
+                self.websocket,
+                user_id,
+                [generate_text_message(
+                    f"[ISCC 每日定时刷新] 北京时间 {timestamp} 自动登录失败：{e}"
+                )],
+            )
+            return
+
+        with DataManager() as dm:
+            dm.save_session(user_id, session)
+
+        # 登录成功后顺带刷新 nonce 缓存
+        regular_nonce = ""
+        arena_nonce = ""
+        try:
+            regular_nonce, arena_nonce = await client.fetch_nonces()
+            if regular_nonce or arena_nonce:
+                with DataManager() as dm:
+                    dm.save_nonce(user_id, regular_nonce, arena_nonce)
+        except Exception as e:
+            logger.warning(f"[{MODULE_NAME}]ISCC 每日定时刷新 nonce 失败: {e}")
+
+        lines = [
+            f"[ISCC 每日定时刷新] 北京时间 {timestamp}",
+            "自动重新登录成功，session 已更新。",
+            f"新的 session：{session}",
+        ]
+        if regular_nonce or arena_nonce:
+            lines.append(f"练武题 nonce：{regular_nonce or '（未获取）'}")
+            lines.append(f"擂台题 nonce：{arena_nonce or '（未获取）'}")
+        await send_private_msg(
+            self.websocket,
+            user_id,
+            [generate_text_message("\n".join(lines))],
+        )

--- a/app/modules/ISCCSubmit/handlers/handle_meta_event.py
+++ b/app/modules/ISCCSubmit/handlers/handle_meta_event.py
@@ -13,12 +13,13 @@ from .iscc_client import ISCCClient
 
 BEIJING_TZ = timezone(timedelta(hours=8))
 
+# DB meta 表中记录"最近一次每日刷新日期（北京时间 YYYY-MM-DD）"使用的 key
+DAILY_REFRESH_META_KEY = "daily_refresh_last_date"
+
 
 class MetaEventHandler:
     _last_run_at = 0
     _running = False
-    # 记录 "YYYY-MM-DD" 字符串，用于保证每个北京时间自然日只刷新一次
-    _last_daily_refresh_date = ""
 
     def __init__(self, websocket, msg):
         self.websocket = websocket
@@ -48,25 +49,28 @@ class MetaEventHandler:
         try:
             with DataManager() as dm:
                 accounts = dm.get_all_accounts()
+                last_refresh_date = dm.get_meta(DAILY_REFRESH_META_KEY)
 
             beijing_now = datetime.now(BEIJING_TZ)
-            should_daily_refresh = self._should_daily_refresh(beijing_now)
+            should_daily_refresh = self._should_daily_refresh(beijing_now, last_refresh_date)
+
+            if should_daily_refresh:
+                # 先落库标记，避免刷新过程中进程崩溃、重启后又触发一轮
+                today = beijing_now.strftime("%Y-%m-%d")
+                with DataManager() as dm:
+                    dm.set_meta(DAILY_REFRESH_META_KEY, today)
 
             for account in accounts:
                 if should_daily_refresh:
                     await self._daily_refresh_account(account, beijing_now)
                 else:
                     await self._keep_account_alive(account)
-
-            if should_daily_refresh:
-                # 不管账号是否处理成功，都标记当日已触发，避免同一分钟重复执行
-                self.__class__._last_daily_refresh_date = beijing_now.strftime("%Y-%m-%d")
         finally:
             self.__class__._running = False
 
-    def _should_daily_refresh(self, beijing_now: datetime) -> bool:
+    def _should_daily_refresh(self, beijing_now: datetime, last_refresh_date: str) -> bool:
         today = beijing_now.strftime("%Y-%m-%d")
-        if self.__class__._last_daily_refresh_date == today:
+        if last_refresh_date == today:
             return False
         # 到达或超过 07:50 即触发。心跳最小间隔 60s，能保证当日被触发。
         if beijing_now.hour > DAILY_REFRESH_HOUR:
@@ -133,8 +137,9 @@ class MetaEventHandler:
         try:
             regular_nonce, arena_nonce = await client.fetch_nonces()
             if regular_nonce or arena_nonce:
+                # 用 update_nonce + `x or None`：抓到空串视为"这次没拿到"，保留 DB 原值
                 with DataManager() as dm:
-                    dm.save_nonce(user_id, regular_nonce, arena_nonce)
+                    dm.update_nonce(user_id, regular_nonce or None, arena_nonce or None)
         except Exception as e:
             logger.warning(f"[{MODULE_NAME}]ISCC 每日定时刷新 nonce 失败: {e}")
 

--- a/app/modules/ISCCSubmit/handlers/iscc_client.py
+++ b/app/modules/ISCCSubmit/handlers/iscc_client.py
@@ -83,13 +83,19 @@ class ISCCClient:
         return bool(self._extract_team_id(html)) and "login" not in html.lower()
 
     async def fetch_nonces(self) -> tuple[str, str]:
-        """获取练武题与擂台题的 nonce，返回 (regular_nonce, arena_nonce)。任一页面失败视为空串。"""
+        """获取练武题与擂台题的 nonce，返回 (regular_nonce, arena_nonce)。
+
+        - 登录失效异常会向外抛出，让调用侧决定是否重登录重试。
+        - 其它网络/HTTP 错误视为"这次取不到"，对应字段返回空串。
+        """
         async with self._operation_session():
             async def _fetch(path: str) -> str:
                 try:
                     html = await self._request_text("GET", path, referer=f"{self.base_url}/")
                     return self._extract_nonce(html)
-                except ISCCClientError:
+                except ISCCClientError as e:
+                    if "登录状态失效" in str(e):
+                        raise
                     return ""
 
             regular_nonce = await _fetch("/challenges")

--- a/app/modules/ISCCSubmit/handlers/iscc_client.py
+++ b/app/modules/ISCCSubmit/handlers/iscc_client.py
@@ -82,6 +82,20 @@ class ISCCClient:
             return False
         return bool(self._extract_team_id(html)) and "login" not in html.lower()
 
+    async def fetch_nonces(self) -> tuple[str, str]:
+        """获取练武题与擂台题的 nonce，返回 (regular_nonce, arena_nonce)。任一页面失败视为空串。"""
+        async with self._operation_session():
+            async def _fetch(path: str) -> str:
+                try:
+                    html = await self._request_text("GET", path, referer=f"{self.base_url}/")
+                    return self._extract_nonce(html)
+                except ISCCClientError:
+                    return ""
+
+            regular_nonce = await _fetch("/challenges")
+            arena_nonce = await _fetch("/arena")
+            return regular_nonce, arena_nonce
+
     async def keep_alive_arena_score(self) -> str:
         async with self._operation_session():
             html = await self._request_text("GET", "/arena", referer=f"{self.base_url}/")


### PR DESCRIPTION
## 变更内容

- 新增 isccsession 命令，机器人私聊回复当前管理员账号的 session
- 新增 nonce 持久化存储，并新增 isccnonce 命令回复最新的练武题和擂台题 nonce
- 每天北京时间 07:50 自动重新登录一次，刷新 session 后主动私聊汇报给管理员

## 说明

依托现有 heartbeat 元事件，每分钟轮询一次当前北京时间以触发定时刷新。