### PR TITLE
feat(ISCCSubmit): 新增练武/擂台未解题缓存与 iscc刷新命令

### DIFF
--- a/app/modules/ISCCSubmit/__init__.py
+++ b/app/modules/ISCCSubmit/__init__.py
@@ -18,6 +18,7 @@ CONFIG_COMMAND = "iscc配置"
 HELP_COMMAND = "iscc帮助"
 SESSION_COMMAND = "isccsession"
 NONCE_COMMAND = "isccnonce"
+REFRESH_COMMAND = "iscc刷新"
 FLAG_PATTERN = r"^ISCC\{.+\}$"
 
 # 每日自动刷新 session 的北京时间（24 小时制）
@@ -37,6 +38,7 @@ COMMANDS = {
     "ISCC{xxxxx}": "提交 flag 到 ISCC 平台未解题目",
     SESSION_COMMAND: "查询当前 ISCC session",
     NONCE_COMMAND: "查询当前 ISCC 练武题和擂台题 nonce",
+    REFRESH_COMMAND: "立即刷新练武题/擂台题未解题目缓存",
     MONITOR_ADD_COMMAND: "添加监控的擂台赛 team id，用法：isccm添加 <team_id> [备注]",
     MONITOR_REMOVE_COMMAND: "删除监控的擂台赛 team id，用法：isccm删除 <team_id>",
     MONITOR_LIST_COMMAND: "查看当前监控的擂台赛 team id 列表",

--- a/app/modules/ISCCSubmit/handlers/data_manager.py
+++ b/app/modules/ISCCSubmit/handlers/data_manager.py
@@ -78,6 +78,19 @@ class DataManager:
             )
             """
         )
+        # 未解题目缓存：按 user_id + track 维度记录当前可提交的 challenge id 列表
+        # ids 用逗号分隔的字符串保存（不会很大，几十题量级），避免再建一张明细表
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS iscc_unsolved_cache (
+                user_id TEXT NOT NULL,
+                track TEXT NOT NULL,
+                ids TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (user_id, track)
+            )
+            """
+        )
         self.conn.commit()
 
     def __enter__(self):
@@ -193,6 +206,61 @@ class DataManager:
             """,
             (key, value, self._now_text()),
         )
+
+    # ==================== 未解题目缓存 ====================
+
+    def get_unsolved_ids(self, user_id: str, track: str) -> Optional[list[int]]:
+        """读取某用户某赛道的未解题缓存。返回 None 表示无缓存（区别于"已知为空"）。"""
+        self.cursor.execute(
+            """
+            SELECT ids FROM iscc_unsolved_cache WHERE user_id = ? AND track = ?
+            """,
+            (user_id, track),
+        )
+        row = self.cursor.fetchone()
+        if row is None:
+            return None
+        raw = (row["ids"] or "").strip()
+        if not raw:
+            return []
+        return [int(x) for x in raw.split(",") if x.strip().isdigit()]
+
+    def get_unsolved_meta(self, user_id: str, track: str) -> Optional[dict]:
+        self.cursor.execute(
+            """
+            SELECT ids, updated_at FROM iscc_unsolved_cache
+            WHERE user_id = ? AND track = ?
+            """,
+            (user_id, track),
+        )
+        row = self.cursor.fetchone()
+        return dict(row) if row else None
+
+    def save_unsolved_ids(self, user_id: str, track: str, ids: list[int]):
+        """覆盖式保存未解题缓存。"""
+        joined = ",".join(str(int(x)) for x in ids)
+        self.cursor.execute(
+            """
+            INSERT INTO iscc_unsolved_cache (user_id, track, ids, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(user_id, track)
+            DO UPDATE SET ids = excluded.ids,
+                          updated_at = excluded.updated_at
+            """,
+            (user_id, track, joined, self._now_text()),
+        )
+
+    def remove_unsolved_ids(self, user_id: str, track: str, removed_ids: list[int]):
+        """从未解缓存里剔除若干 id（提交成功/已解题之后调用）。无缓存时静默跳过。"""
+        if not removed_ids:
+            return
+        current = self.get_unsolved_ids(user_id, track)
+        if current is None:
+            return
+        remaining = [cid for cid in current if cid not in set(removed_ids)]
+        if remaining == current:
+            return
+        self.save_unsolved_ids(user_id, track, remaining)
 
     # ==================== 擂台赛监控 ====================
 

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -17,11 +17,18 @@ from .. import (
     MONITOR_LIST_COMMAND,
     MONITOR_REMOVE_COMMAND,
     NONCE_COMMAND,
+    REFRESH_COMMAND,
     SESSION_COMMAND,
     SWITCH_NAME,
 )
 from .data_manager import DataManager
-from .iscc_client import ISCCClient, ISCCClientError, SubmitResult
+from .iscc_client import (
+    ARENA_TRACK,
+    ISCCClient,
+    ISCCClientError,
+    REGULAR_TRACK,
+    SubmitResult,
+)
 from .monitor_service import MonitorLock, run_monitor_once
 
 
@@ -55,6 +62,9 @@ class PrivateMessageHandler:
                 return
             if self.raw_message.lower() == NONCE_COMMAND.lower():
                 await self._handle_query_nonce()
+                return
+            if self.raw_message == REFRESH_COMMAND:
+                await self._handle_refresh_unsolved()
                 return
             if self.raw_message == MONITOR_LIST_COMMAND:
                 await self._handle_monitor_list()
@@ -104,7 +114,18 @@ class PrivateMessageHandler:
 
         with DataManager() as dm:
             dm.save_account(self.user_id, username, password, session)
-        await self._reply("ISCC 登录成功，账号、密码和 session 已保存。")
+
+        # 登录成功后顺便把未解题缓存建起来，这样后续提交 flag 可以直接走缓存
+        ok, regular_n, arena_n, err = await self._refresh_unsolved_cache(client)
+
+        msg_lines = ["ISCC 登录成功，账号、密码和 session 已保存。"]
+        if ok:
+            msg_lines.append(
+                f"未解题缓存已建立：练武题 {regular_n} 题，擂台题 {arena_n} 题。"
+            )
+        elif err:
+            msg_lines.append(f"未解题缓存建立失败：{err}")
+        await self._reply("\n".join(msg_lines))
 
     async def _handle_submit_flag(self):
         with DataManager() as dm:
@@ -115,10 +136,103 @@ class PrivateMessageHandler:
 
         await self._reply("已开始提交 flag，请等待结果。")
         client = await self._ensure_client(account)
-        results = await client.submit_flag_to_unsolved(self.raw_message)
+
+        # 优先用缓存；任一赛道缺缓存时，现场拉一次并落库，保证结果准。
+        prefetched = await self._resolve_unsolved_ids(client)
+
+        results = await client.submit_flag_to_unsolved(
+            self.raw_message, prefetched_ids=prefetched
+        )
         await self._save_session(client.session_cookie)
+        self._update_cache_after_submit(results)
         await self._refresh_nonces(client, account)
         await self._reply(self._format_results(results))
+
+    async def _resolve_unsolved_ids(
+        self, client: ISCCClient
+    ) -> dict[str, list[int]]:
+        """读取未解题缓存；缓存缺失时实时拉一次并落库。出错时返回空 dict 走兜底分支。"""
+        prefetched: dict[str, list[int]] = {}
+        missing_tracks: list[str] = []
+        with DataManager() as dm:
+            for track in (REGULAR_TRACK, ARENA_TRACK):
+                ids = dm.get_unsolved_ids(self.user_id, track)
+                if ids is None:
+                    missing_tracks.append(track)
+                else:
+                    prefetched[track] = ids
+
+        if not missing_tracks:
+            return prefetched
+
+        try:
+            fresh = await client.fetch_unsolved_ids()
+        except Exception as e:
+            logger.warning(f"[{MODULE_NAME}]flag 提交前拉取未解题失败: {e}")
+            # 让 submit_flag_to_unsolved 自己走兜底的实时拉路径，同时给已有缓存留着
+            return prefetched
+
+        with DataManager() as dm:
+            for track in (REGULAR_TRACK, ARENA_TRACK):
+                if track in fresh:
+                    dm.save_unsolved_ids(self.user_id, track, fresh[track])
+        for track in missing_tracks:
+            prefetched[track] = fresh.get(track, [])
+        return prefetched
+
+    def _update_cache_after_submit(self, results: list[SubmitResult]):
+        """把刚被判为"正确/已解决"的题目从未解缓存里摘掉。"""
+        solved_map: dict[str, list[int]] = {REGULAR_TRACK: [], ARENA_TRACK: []}
+        for item in results:
+            if item.status in {"1", "2"} and item.challenge_id > 0:
+                solved_map.setdefault(item.track, []).append(item.challenge_id)
+        if not any(solved_map.values()):
+            return
+        with DataManager() as dm:
+            for track, ids in solved_map.items():
+                if ids:
+                    dm.remove_unsolved_ids(self.user_id, track, ids)
+
+    async def _refresh_unsolved_cache(
+        self, client: ISCCClient
+    ) -> tuple[bool, int, int, str]:
+        """主动刷新未解题缓存，返回 (是否成功, 练武未解数, 擂台未解数, 错误信息)。"""
+        try:
+            fresh = await client.fetch_unsolved_ids()
+        except Exception as e:
+            logger.warning(f"[{MODULE_NAME}]刷新未解题缓存失败: {e}")
+            return False, 0, 0, str(e)
+        with DataManager() as dm:
+            dm.save_unsolved_ids(self.user_id, REGULAR_TRACK, fresh.get(REGULAR_TRACK, []))
+            dm.save_unsolved_ids(self.user_id, ARENA_TRACK, fresh.get(ARENA_TRACK, []))
+        await self._save_session(client.session_cookie)
+        return True, len(fresh.get(REGULAR_TRACK, [])), len(fresh.get(ARENA_TRACK, [])), ""
+
+    async def _handle_refresh_unsolved(self):
+        with DataManager() as dm:
+            account = dm.get_account(self.user_id)
+        if not account:
+            await self._reply("尚未配置 ISCC 账号，请先发送：iscc配置 <账号> <密码>")
+            return
+
+        await self._reply("正在刷新未解题缓存，请稍候...")
+        client = await self._ensure_client(account)
+        ok, regular_n, arena_n, err = await self._refresh_unsolved_cache(client)
+        if ok:
+            with DataManager() as dm:
+                regular_meta = dm.get_unsolved_meta(self.user_id, REGULAR_TRACK)
+                arena_meta = dm.get_unsolved_meta(self.user_id, ARENA_TRACK)
+            ts = (
+                regular_meta and regular_meta.get("updated_at")
+            ) or (arena_meta and arena_meta.get("updated_at")) or "刚刚"
+            await self._reply(
+                "未解题缓存已刷新\n"
+                f"练武题：{regular_n} 题未解\n"
+                f"擂台题：{arena_n} 题未解\n"
+                f"更新时间：{ts}"
+            )
+        else:
+            await self._reply(f"刷新未解题缓存失败：{err}")
 
     async def _handle_query_session(self):
         with DataManager() as dm:
@@ -245,13 +359,15 @@ class PrivateMessageHandler:
             "ISCC{xxxxx}：提交 flag 到练武题和擂台题所有未解题目\n"
             f"{SESSION_COMMAND}：查询当前 ISCC session\n"
             f"{NONCE_COMMAND}：查询当前练武题和擂台题 nonce\n"
+            f"{REFRESH_COMMAND}：立即刷新练武题/擂台题未解题目缓存\n"
             f"{MONITOR_ADD_COMMAND} <team_id> [备注]：添加擂台赛监控目标\n"
             f"{MONITOR_REMOVE_COMMAND} <team_id>：删除擂台赛监控目标\n"
             f"{MONITOR_LIST_COMMAND}：查看擂台赛监控目标列表\n"
             f"{MONITOR_CHECK_COMMAND}：立即触发一次擂台赛监控轮询\n"
             f"{SWITCH_NAME}{MENU_COMMAND}：查看模块菜单\n"
-            "说明：开启模块并配置好账号后，心跳会驱动 session 保活/每日刷新；\n"
-            "同时会按节流间隔轮询所有监控目标的擂台赛解题详情，新通过题目会私聊通知管理员。"
+            "说明：开启模块并配置好账号后，心跳会驱动 session 保活/每日刷新，\n"
+            "同时定期刷新未解题目缓存；收到 flag 时会直接对缓存中的未解题目批量提交。\n"
+            "擂台赛监控会按节流间隔轮询所有监控目标的解题详情，新通过题目会私聊通知管理员。"
         )
 
     # ==================== 擂台赛监控命令 ====================

--- a/app/modules/ISCCSubmit/handlers/handle_meta_event.py
+++ b/app/modules/ISCCSubmit/handlers/handle_meta_event.py
@@ -9,7 +9,7 @@ from utils.generate import generate_text_message
 
 from .. import DAILY_REFRESH_HOUR, DAILY_REFRESH_MINUTE, MODULE_NAME
 from .data_manager import DataManager
-from .iscc_client import ISCCClient
+from .iscc_client import ARENA_TRACK, ISCCClient, ISCCClientError, REGULAR_TRACK
 from .monitor_service import MonitorLock, run_monitor_once
 
 
@@ -116,31 +116,51 @@ class MetaEventHandler:
     async def _keep_account_alive(self, account: dict):
         user_id = str(account["user_id"])
         client = ISCCClient(account.get("session", ""))
+        keep_alive_ok = False
         try:
             await client.keep_alive_arena_score()
-            return
+            keep_alive_ok = True
         except Exception as e:
             logger.warning(f"[{MODULE_NAME}]ISCC session 保活失败，准备重新登录: {e}")
 
-        try:
-            session = await client.login(account["username"], account["password"])
-            with DataManager() as dm:
-                dm.save_session(user_id, session)
-            await send_private_msg(
-                self.websocket,
-                user_id,
-                [generate_text_message(
-                    "ISCC 登录状态已过期，机器人已自动重新登录并刷新 session。\n"
-                    f"新的 session：{session}"
-                )],
-            )
-        except Exception as e:
-            logger.error(f"[{MODULE_NAME}]ISCC 自动重新登录失败: {e}")
-            await send_private_msg(
-                self.websocket,
-                user_id,
-                [generate_text_message(f"ISCC 登录状态已过期，自动重新登录失败：{e}")],
-            )
+        if not keep_alive_ok:
+            try:
+                session = await client.login(account["username"], account["password"])
+                with DataManager() as dm:
+                    dm.save_session(user_id, session)
+                await send_private_msg(
+                    self.websocket,
+                    user_id,
+                    [generate_text_message(
+                        "ISCC 登录状态已过期，机器人已自动重新登录并刷新 session。\n"
+                        f"新的 session：{session}"
+                    )],
+                )
+                keep_alive_ok = True
+            except ISCCClientError as e:
+                if e.is_transient_server_error:
+                    # 5xx 视为对端临时不可用，等下个心跳自动重试，不打扰管理员
+                    logger.warning(
+                        f"[{MODULE_NAME}]ISCC 重新登录遇到服务端 {e.status_code}，"
+                        "静默等待下个心跳重试"
+                    )
+                else:
+                    logger.error(f"[{MODULE_NAME}]ISCC 自动重新登录失败: {e}")
+                    await send_private_msg(
+                        self.websocket,
+                        user_id,
+                        [generate_text_message(f"ISCC 登录状态已过期，自动重新登录失败：{e}")],
+                    )
+            except Exception as e:
+                logger.error(f"[{MODULE_NAME}]ISCC 自动重新登录失败: {e}")
+                await send_private_msg(
+                    self.websocket,
+                    user_id,
+                    [generate_text_message(f"ISCC 登录状态已过期，自动重新登录失败：{e}")],
+                )
+
+        if keep_alive_ok:
+            await self._refresh_unsolved_cache(user_id, client)
 
     async def _daily_refresh_account(self, account: dict, beijing_now: datetime):
         user_id = str(account["user_id"])
@@ -151,6 +171,25 @@ class MetaEventHandler:
 
         try:
             session = await client.login(username, password)
+        except ISCCClientError as e:
+            if e.is_transient_server_error:
+                # 5xx 时不通知管理员，并清掉当日已触发标记，让下一次心跳继续重试
+                logger.warning(
+                    f"[{MODULE_NAME}]ISCC 每日定时登录遇到服务端 {e.status_code}，"
+                    "静默等待下个心跳重试"
+                )
+                with DataManager() as dm:
+                    dm.set_meta(DAILY_REFRESH_META_KEY, "")
+                return
+            logger.error(f"[{MODULE_NAME}]ISCC 每日定时登录失败: {e}")
+            await send_private_msg(
+                self.websocket,
+                user_id,
+                [generate_text_message(
+                    f"[ISCC 每日定时刷新] 北京时间 {timestamp} 自动登录失败：{e}"
+                )],
+            )
+            return
         except Exception as e:
             logger.error(f"[{MODULE_NAME}]ISCC 每日定时登录失败: {e}")
             await send_private_msg(
@@ -185,8 +224,30 @@ class MetaEventHandler:
         if regular_nonce or arena_nonce:
             lines.append(f"练武题 nonce：{regular_nonce or '（未获取）'}")
             lines.append(f"擂台题 nonce：{arena_nonce or '（未获取）'}")
+
+        # 每日刷新顺便重建一次未解题缓存，减少一天内再去实时拉取
+        regular_unsolved, arena_unsolved = await self._refresh_unsolved_cache(user_id, client)
+        if regular_unsolved is not None and arena_unsolved is not None:
+            lines.append(
+                f"未解题缓存：练武题 {regular_unsolved} 题 / 擂台题 {arena_unsolved} 题"
+            )
+
         await send_private_msg(
             self.websocket,
             user_id,
             [generate_text_message("\n".join(lines))],
         )
+
+    async def _refresh_unsolved_cache(
+        self, user_id: str, client: ISCCClient
+    ) -> tuple[int | None, int | None]:
+        """调用 client.fetch_unsolved_ids 并落库；失败返回 (None, None)。"""
+        try:
+            fresh = await client.fetch_unsolved_ids()
+        except Exception as e:
+            logger.warning(f"[{MODULE_NAME}]刷新未解题缓存失败: {e}")
+            return None, None
+        with DataManager() as dm:
+            dm.save_unsolved_ids(user_id, REGULAR_TRACK, fresh.get(REGULAR_TRACK, []))
+            dm.save_unsolved_ids(user_id, ARENA_TRACK, fresh.get(ARENA_TRACK, []))
+        return len(fresh.get(REGULAR_TRACK, [])), len(fresh.get(ARENA_TRACK, []))

--- a/app/modules/ISCCSubmit/handlers/iscc_client.py
+++ b/app/modules/ISCCSubmit/handlers/iscc_client.py
@@ -29,6 +29,19 @@ class ChallengeContext:
     challenge_ids: list[int]
 
 
+# 赛道标签 -> (未解题提交前缀 / referer 页面)
+REGULAR_TRACK = "练武题"
+ARENA_TRACK = "擂台题"
+TRACK_SUBMIT_PATH = {
+    REGULAR_TRACK: "/chal",
+    ARENA_TRACK: "/are",
+}
+TRACK_REFERER_PATH = {
+    REGULAR_TRACK: "/challenges",
+    ARENA_TRACK: "/arena",
+}
+
+
 @dataclass
 class SubmitResult:
     track: str
@@ -58,7 +71,19 @@ class TeamArenaSnapshot:
 
 
 class ISCCClientError(Exception):
-    pass
+    """ISCC 客户端异常。
+
+    - `status_code` 为 HTTP 状态码（可用时），便于调用方区分短暂性服务端错误（5xx）与
+      业务错误（如登录失败、nonce 过期等）。
+    """
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+    @property
+    def is_transient_server_error(self) -> bool:
+        return self.status_code is not None and 500 <= self.status_code < 600
 
 
 class ISCCClient:
@@ -84,7 +109,10 @@ class ISCCClient:
                 },
             ) as response:
                 if response.status >= 400:
-                    raise ISCCClientError(f"登录失败，HTTP 状态码 {response.status}")
+                    raise ISCCClientError(
+                        f"登录失败，HTTP 状态码 {response.status}",
+                        status_code=response.status,
+                    )
                 cookie = self._extract_session_cookie(response)
                 if not cookie:
                     raise ISCCClientError("登录失败，响应中未返回 session")
@@ -188,44 +216,81 @@ class ISCCClient:
                 return table
         return None
 
-    async def submit_flag_to_unsolved(self, flag: str) -> list[SubmitResult]:
-        async with self._operation_session():
-            regular_result, arena_result = await asyncio.gather(self._regular_context(), self._arena_context(), return_exceptions=True)
-            contexts = []
-            errors = []
-            for track, result in (("练武题", regular_result), ("擂台题", arena_result)):
-                if isinstance(result, Exception):
-                    errors.append(SubmitResult(track, 0, "error", f"获取题目失败：{result}"))
-                else:
-                    contexts.append(result)
+    async def submit_flag_to_unsolved(
+        self,
+        flag: str,
+        prefetched_ids: dict[str, list[int]] | None = None,
+    ) -> list[SubmitResult]:
+        """对当前所有未解题目提交 flag。
 
-            results = []
+        - `prefetched_ids` 传入 `{"练武题": [...], "擂台题": [...]}` 时，直接使用该列表，
+          不再实时拉取。缓存未命中的赛道会回退到实时拉取（保持旧逻辑兼容）。
+        """
+        prefetched_ids = prefetched_ids or {}
+        async with self._operation_session():
+            contexts: list[ChallengeContext] = []
+            errors: list[SubmitResult] = []
+
+            for track in (REGULAR_TRACK, ARENA_TRACK):
+                ids = prefetched_ids.get(track)
+                if ids is not None:
+                    contexts.append(
+                        ChallengeContext(track, TRACK_SUBMIT_PATH[track], sorted(set(ids)))
+                    )
+                    continue
+                try:
+                    if track == REGULAR_TRACK:
+                        contexts.append(await self._regular_context())
+                    else:
+                        contexts.append(await self._arena_context())
+                except Exception as e:
+                    errors.append(SubmitResult(track, 0, "error", f"获取题目失败：{e}"))
+
+            results: list[SubmitResult] = []
             for context in contexts:
                 for challenge_id in context.challenge_ids:
                     results.append(await self._submit_challenge(context, challenge_id, flag))
             return [*errors, *results]
 
+    async def fetch_unsolved_ids(self) -> dict[str, list[int]]:
+        """拉取当前账号在两个赛道上的未解题 id，返回 `{"练武题": [...], "擂台题": [...]}`。
+
+        任一赛道失败时把异常包装成 ISCCClientError 抛出（由调用侧决定是否整体失败或部分保留）。
+        """
+        async with self._operation_session():
+            regular_ctx, arena_ctx = await asyncio.gather(
+                self._regular_context(), self._arena_context()
+            )
+            return {
+                REGULAR_TRACK: list(regular_ctx.challenge_ids),
+                ARENA_TRACK: list(arena_ctx.challenge_ids),
+            }
+
     async def _regular_context(self) -> ChallengeContext:
-        html = await self._request_text("GET", "/challenges", referer=f"{self.base_url}/")
-        nonce = self._extract_nonce(html)
-        team_id = self._extract_team_id(html)
-        if not nonce or not team_id:
-            raise ISCCClientError("获取练武题页面失败，缺少 nonce 或队伍信息")
-        challenge_ids = self._extract_regular_challenge_ids(html)
-        solved_ids = await self._regular_solved_ids(team_id)
-        return ChallengeContext("练武题", "/chal", sorted(challenge_ids - solved_ids))
+        challenge_ids, solved_ids = await asyncio.gather(
+            self._regular_challenge_ids(), self._regular_solved_ids()
+        )
+        return ChallengeContext(REGULAR_TRACK, TRACK_SUBMIT_PATH[REGULAR_TRACK], sorted(challenge_ids - solved_ids))
 
     async def _arena_context(self) -> ChallengeContext:
-        html = await self._request_text("GET", "/arena", referer=f"{self.base_url}/")
-        nonce = self._extract_nonce(html)
-        if not nonce:
-            raise ISCCClientError("获取擂台题页面失败，缺少 nonce")
         challenge_ids, solved_ids = await asyncio.gather(self._arena_challenge_ids(), self._arena_solved_ids())
-        return ChallengeContext("擂台题", "/are", sorted(challenge_ids - solved_ids))
+        return ChallengeContext(ARENA_TRACK, TRACK_SUBMIT_PATH[ARENA_TRACK], sorted(challenge_ids - solved_ids))
 
-    async def _regular_solved_ids(self, team_id: str) -> set[int]:
-        data = await self._request_json("GET", f"/solves/{team_id}", referer=f"{self.base_url}/team/{team_id}")
+    async def _regular_solved_ids(self) -> set[int]:
+        """当前登录账号已解的练武题 id，走 session 维度的 /solves 接口。"""
+        data = await self._request_json("GET", "/solves", referer=f"{self.base_url}/challenges")
         return {int(item["chalid"]) for item in data.get("solves", []) if str(item.get("chalid", "")).isdigit()}
+
+    async def _regular_challenge_ids(self) -> set[int]:
+        data = await self._request_json("GET", "/chals", referer=f"{self.base_url}/challenges")
+        ids: set[int] = set()
+        # /chals 返回结构常见为 {"game": [...]} 或 {"challenges": [...]}，做兼容
+        for key in ("game", "challenges"):
+            for item in data.get(key, []) or []:
+                cid = item.get("id") if isinstance(item, dict) else None
+                if str(cid).isdigit():
+                    ids.add(int(cid))
+        return ids
 
     async def _arena_challenge_ids(self) -> set[int]:
         data = await self._request_json("GET", "/arenas", referer=f"{self.base_url}/arena")
@@ -238,11 +303,12 @@ class ISCCClient:
     async def _submit_challenge(self, context: ChallengeContext, challenge_id: int, flag: str) -> SubmitResult:
         try:
             nonce = await self._get_nonce_for_track(context.track)
+            referer_path = TRACK_REFERER_PATH.get(context.track, "/")
             text = await self._request_text(
                 "POST",
                 f"{context.submit_path}/{challenge_id}",
                 data={"key": flag, "nonce": nonce},
-                referer=f"{self.base_url}/arena" if context.track == "擂台题" else f"{self.base_url}/challenges",
+                referer=f"{self.base_url}{referer_path}",
                 ajax=True,
             )
             status = text.strip()
@@ -251,7 +317,7 @@ class ISCCClient:
             return SubmitResult(context.track, challenge_id, "error", f"提交异常：{e}")
 
     async def _get_nonce_for_track(self, track: str) -> str:
-        path = "/arena" if track == "擂台题" else "/challenges"
+        path = TRACK_REFERER_PATH.get(track, "/challenges")
         html = await self._request_text("GET", path, referer=f"{self.base_url}/")
         nonce = self._extract_nonce(html)
         if not nonce:
@@ -264,7 +330,10 @@ class ISCCClient:
             text = await response.text()
             self._sync_session_cookie()
             if response.status >= 400:
-                raise ISCCClientError(f"{method} {path} 失败，HTTP 状态码 {response.status}")
+                raise ISCCClientError(
+                    f"{method} {path} 失败，HTTP 状态码 {response.status}",
+                    status_code=response.status,
+                )
             if self._looks_like_login_page(text):
                 raise ISCCClientError("登录状态失效")
             return text
@@ -274,7 +343,10 @@ class ISCCClient:
         async with self._request_session().request(method, f"{self.base_url}{path}", headers=headers) as response:
             self._sync_session_cookie()
             if response.status >= 400:
-                raise ISCCClientError(f"{method} {path} 失败，HTTP 状态码 {response.status}")
+                raise ISCCClientError(
+                    f"{method} {path} 失败，HTTP 状态码 {response.status}",
+                    status_code=response.status,
+                )
             return await response.json(content_type=None)
 
     @asynccontextmanager
@@ -339,12 +411,6 @@ class ISCCClient:
     def _extract_team_id(self, html: str) -> str:
         match = re.search(r'href=["\']/team/([0-9a-fA-F]+)["\']', html)
         return match.group(1) if match else ""
-
-    def _extract_regular_challenge_ids(self, html: str) -> set[int]:
-        ids = {int(value) for value in re.findall(r'href=["\']/chal/(\d+)["\']', html)}
-        ids.update(int(value) for value in re.findall(r'data-id=["\'](\d+)["\']', html))
-        ids.update(int(value) for value in re.findall(r'id=["\']chal-(\d+)["\']', html))
-        return ids
 
     def _looks_like_login_page(self, text: str) -> bool:
         lowered = text.lower()


### PR DESCRIPTION
## Summary

- 修复练武题赛道因 HTML 解析失败而在 flag 提交结果中完全缺失的问题：改走 /chals JSON（题目列表）和 /solves（已解列表，不再依赖 team_id）
- 新增按用户 + 赛道维度的未解题缓存（iscc_unsolved_cache 表）：提交 flag 时优先读缓存，缺失赛道实时补一次并落库；正确/已解的题目自动从缓存剔除
- 新增 iscc刷新 命令：手动重建未解题缓存并回显两个赛道的剩余题数
- 心跳保活、iscc配置 登录成功、每日定时刷新均顺带重建一次未解题缓存
- 重新登录/每日定时登录遇到 5xx 时静默等待下一次心跳重试，不再通知管理员；每日刷新遇到 5xx 会清空当日已触发标记以便重试

## Test Plan

- `python3 -m compileall app/modules/ISCCSubmit` 通过
- 建议在部署后通过 `iscc刷新` 和一次 flag 提交实际验证 /chals、/solves 接口的字段解析