### PR TITLE
fix(GroupQRDetector): 修复容器内 libGL.so.1 缺失导致 OpenCV 无法加载

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,16 @@ WORKDIR /app
 # 明确声明东八区（Asia/Shanghai）时区，避免基础镜像默认 UTC
 # 导致容器内 datetime.now() 与日志时间与北京时间不一致。
 # slim 镜像默认不含 tzdata，需要显式安装。
+#
+# OpenCV（opencv-python）在 import 时会 dlopen libGL.so.1 / libglib-2.0.so.0，
+# 否则 GroupQRDetector 启动会报：
+#   ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+# slim 基础镜像不含这两个库，需在此安装 libgl1 + libglib2.0-0。
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tzdata \
+    && apt-get install -y --no-install-recommends \
+        tzdata \
+        libgl1 \
+        libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone


### PR DESCRIPTION
## Summary

GroupQRDetector 依赖 opencv-python，而 OpenCV 在 import 时需要系统库 libGL.so.1。
基础镜像 python3.12-bookworm-slim 不包含该库，运行时会报：
libGL.so.1: cannot open shared object file: No such file or directory

本 PR 会在 Dockerfile 中补齐 OpenCV 所需的最小系统依赖。

## Test Plan

- 构建镜像后进入容器，import cv2 不再报缺库
- GroupQRDetector 模块能正常加载