### PR TITLE
feat: 重构 deploy 流程为远程构建并优化 ISCC flag 提取容错

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 WORKDIR /app
 
+# 接入国内镜像源加速依赖安装：
+# - apt 使用清华大学 TUNA 的 Debian / debian-security 镜像，bookworm-slim 采用
+#   DEB822 格式的 /etc/apt/sources.list.d/debian.sources，通过 sed 直接替换默认 URI。
+# - uv/pip 通过 UV_DEFAULT_INDEX 和 PIP_INDEX_URL 指向清华 PyPI 镜像。
+RUN sed -i \
+        -e 's|http://deb.debian.org|https://mirrors.tuna.tsinghua.edu.cn|g' \
+        -e 's|http://security.debian.org|https://mirrors.tuna.tsinghua.edu.cn|g' \
+        /etc/apt/sources.list.d/debian.sources
+
 # 明确声明东八区（Asia/Shanghai）时区，避免基础镜像默认 UTC
 # 导致容器内 datetime.now() 与日志时间与北京时间不一致。
 # slim 镜像默认不含 tzdata，需要显式安装。
@@ -19,9 +28,12 @@ RUN apt-get update \
     && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 
+# UV_DEFAULT_INDEX / PIP_INDEX_URL 让 uv sync 直接走清华 PyPI 镜像。
 ENV PYTHONUNBUFFERED=1 \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
+    UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple \
+    PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
     TZ=Asia/Shanghai
 
 COPY pyproject.toml uv.lock ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,15 @@ RUN sed -i \
 # 否则 GroupQRDetector 启动会报：
 #   ImportError: libGL.so.1: cannot open shared object file: No such file or directory
 # slim 基础镜像不含这两个库，需在此安装 libgl1 + libglib2.0-0。
+#
+# DeerSign 模块用 PIL 画签到日历/排行榜时需要中文字体，否则会渲染成方框/乱码。
+# slim 镜像默认不含 CJK 字体，安装 fonts-wqy-microhei（约 10MB，代码首选字体）。
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         tzdata \
         libgl1 \
         libglib2.0-0 \
+        fonts-wqy-microhei \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,6 @@ silent: true
 
 vars:
   BOT_IMAGE: '{{.BOT_IMAGE | default "w1ndysbot:latest"}}'
-  DEPLOY_BUNDLE: '{{.DEPLOY_BUNDLE | default "deploy/dist/w1ndysbot-deploy.tar.gz"}}'
   COMPOSE_FILE: '{{.COMPOSE_FILE | default "deploy/compose.prod.yml"}}'
 
 tasks:
@@ -26,38 +25,44 @@ tasks:
       - uv run python app/main.py
 
   build-image:
-    desc: 构建机器人 Docker 镜像
+    desc: 构建机器人 Docker 镜像（本地调试用，正式部署改在远程服务器 build）
     cmds:
       - docker build -t {{.BOT_IMAGE}} .
 
-  package-deploy:
-    desc: 打包 bot 镜像和生产运维配置（不含 napcat，napcat 由服务器自行拉取）
-    deps:
-      - build-image
-    cmds:
-      - mkdir -p deploy/dist
-      - docker save -o deploy/dist/w1ndysbot-images.tar {{.BOT_IMAGE}}
-      - tar -czf {{.DEPLOY_BUNDLE}} deploy/compose.prod.yml deploy/.env.example deploy/dist/w1ndysbot-images.tar
-
   deploy:
-    desc: 仅部署并重启 bot 到生产服务器（napcat 由服务器自行拉取与维护），示例 task deploy HOST=1.2.3.4 PORT=22 USER=root DIR=/srv/app
-    deps:
-      - package-deploy
+    desc: 上传源码到远程服务器并在远程 build/up，示例 task deploy HOST=1.2.3.4 PORT=22 USER=root DIR=/opt/w1ndysbot
     vars:
       HOST: '{{.HOST | default "mylinux"}}'
       PORT: '{{.PORT | default "22"}}'
       USER: '{{.USER | default "root"}}'
       DIR: '{{.DIR | default "/opt/w1ndysbot"}}'
     cmds:
-      - ssh -p {{.PORT}} {{.USER}}@{{.HOST}} "mkdir -p {{.DIR}}"
-      - scp -P {{.PORT}} {{.DEPLOY_BUNDLE}} {{.USER}}@{{.HOST}}:{{.DIR}}/w1ndysbot-deploy.tar.gz
+      # 1) 确保目标目录存在
+      - ssh -p {{.PORT}} {{.USER}}@{{.HOST}} "mkdir -p {{.DIR}} {{.DIR}}/app/data {{.DIR}}/app/logs"
+      # 2) 同步源码：只上传构建/运行所需的代码与部署清单，跳过 .git、data/、logs/、缓存等
+      - |
+        rsync -az --delete \
+          --exclude='.git' \
+          --exclude='.venv' \
+          --exclude='__pycache__' \
+          --exclude='*.pyc' \
+          --exclude='.ruff_cache' \
+          --exclude='.pytest_cache' \
+          --exclude='data' \
+          --exclude='logs' \
+          --exclude='napcat' \
+          --exclude='deploy/dist' \
+          --exclude='*.tar' \
+          --exclude='*.tar.gz' \
+          --exclude='.env' \
+          -e "ssh -p {{.PORT}}" \
+          ./ {{.USER}}@{{.HOST}}:{{.DIR}}/
+      # 3) 在远程服务器构建镜像并重启 bot；env 文件首次部署时从样例拷贝
       - |
         ssh -p {{.PORT}} {{.USER}}@{{.HOST}} "cd {{.DIR}} && \
-          tar -xzf w1ndysbot-deploy.tar.gz --strip-components=1 && \
-          mkdir -p /opt/w1ndysbot/app/data /opt/w1ndysbot/app/logs && \
-          if [ ! -f /opt/w1ndysbot/app/.env ]; then cp .env.example /opt/w1ndysbot/app/.env; fi && \
-          docker load -i dist/w1ndysbot-images.tar && \
-          BOT_IMAGE={{.BOT_IMAGE}} docker compose -f compose.prod.yml up -d --no-deps --force-recreate w1ndysbot && \
+          if [ ! -f app/.env ]; then cp deploy/.env.example app/.env; fi && \
+          BOT_IMAGE={{.BOT_IMAGE}} docker compose -f deploy/compose.prod.yml build w1ndysbot && \
+          BOT_IMAGE={{.BOT_IMAGE}} docker compose -f deploy/compose.prod.yml up -d --no-deps --force-recreate w1ndysbot && \
           docker image prune -f"
 
   prod:up:

--- a/app/modules/ISCCSubmit/__init__.py
+++ b/app/modules/ISCCSubmit/__init__.py
@@ -19,7 +19,9 @@ HELP_COMMAND = "iscc帮助"
 SESSION_COMMAND = "isccsession"
 NONCE_COMMAND = "isccnonce"
 REFRESH_COMMAND = "iscc刷新"
-FLAG_PATTERN = r"^ISCC\{.+\}$"
+# 不再要求消息以 ISCC{ 开头/结尾，只要消息里包含一段 ISCC{...} 就识别成 flag 提交，
+# 提高对客户端转发、引用、上下文带前后缀场景的容错。
+FLAG_PATTERN = r"ISCC\{[^{}]+\}"
 
 # 每日自动刷新 session 的北京时间（24 小时制）
 DAILY_REFRESH_HOUR = 7
@@ -35,7 +37,7 @@ MONITOR_CHECK_COMMAND = "isccm检测"
 COMMANDS = {
     SWITCH_NAME: "系统管理员开关 ISCC 自动提交与擂台赛监控模块",
     CONFIG_COMMAND: "配置 ISCC 账号，用法：iscc配置 <账号> <密码>",
-    "ISCC{xxxxx}": "提交 flag 到 ISCC 平台未解题目",
+    "ISCC{xxxxx}": "提交 flag 到 ISCC 平台未解题目（消息中包含 ISCC{...} 即可，无需独立成行）",
     SESSION_COMMAND: "查询当前 ISCC session",
     NONCE_COMMAND: "查询当前 ISCC 练武题和擂台题 nonce",
     REFRESH_COMMAND: "立即刷新练武题/擂台题未解题目缓存",

--- a/app/modules/ISCCSubmit/__init__.py
+++ b/app/modules/ISCCSubmit/__init__.py
@@ -37,7 +37,7 @@ MONITOR_CHECK_COMMAND = "isccm检测"
 COMMANDS = {
     SWITCH_NAME: "系统管理员开关 ISCC 自动提交与擂台赛监控模块",
     CONFIG_COMMAND: "配置 ISCC 账号，用法：iscc配置 <账号> <密码>",
-    "ISCC{xxxxx}": "提交 flag 到 ISCC 平台未解题目（消息中包含 ISCC{...} 即可，无需独立成行）",
+    "ISCC{xxxxx}": "提交 flag 到 ISCC 平台未解题目（消息中可包含多个 ISCC{...}，会并发提交，无需独立成行）",
     SESSION_COMMAND: "查询当前 ISCC session",
     NONCE_COMMAND: "查询当前 ISCC 练武题和擂台题 nonce",
     REFRESH_COMMAND: "立即刷新练武题/擂台题未解题目缓存",

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -78,9 +78,9 @@ class PrivateMessageHandler:
             if self.raw_message == MONITOR_CHECK_COMMAND:
                 await self._handle_monitor_check()
                 return
-            flag_match = re.search(FLAG_PATTERN, self.raw_message)
-            if flag_match:
-                await self._handle_submit_flag(flag_match.group(0))
+            flags = self._extract_flags(self.raw_message)
+            if flags:
+                await self._handle_submit_flag(flags)
         except Exception as e:
             logger.error(f"[{MODULE_NAME}]处理私聊消息失败: {e}")
             await self._reply(f"ISCC 自动提交处理失败：{e}")
@@ -128,26 +128,48 @@ class PrivateMessageHandler:
             msg_lines.append(f"未解题缓存建立失败：{err}")
         await self._reply("\n".join(msg_lines))
 
-    async def _handle_submit_flag(self, flag: str):
+    async def _handle_submit_flag(self, flags: list[str]):
         with DataManager() as dm:
             account = dm.get_account(self.user_id)
         if not account:
             await self._reply("尚未配置 ISCC 账号，请先发送：iscc配置 <账号> <密码>")
             return
 
-        await self._reply(f"已识别到 flag：{flag}\n已开始提交，请等待结果。")
+        if len(flags) == 1:
+            notice = f"已识别到 flag：{flags[0]}\n已开始提交，请等待结果。"
+        else:
+            bullet = "\n".join(f"- {flag}" for flag in flags)
+            notice = (
+                f"已识别到 {len(flags)} 个 flag，将并发提交：\n{bullet}\n请等待结果。"
+            )
+        await self._reply(notice)
+
         client = await self._ensure_client(account)
 
         # 优先用缓存；任一赛道缺缓存时，现场拉一次并落库，保证结果准。
         prefetched = await self._resolve_unsolved_ids(client)
 
-        results = await client.submit_flag_to_unsolved(
-            flag, prefetched_ids=prefetched
+        flag_results = await client.submit_flags_to_unsolved(
+            flags, prefetched_ids=prefetched
         )
         await self._save_session(client.session_cookie)
-        self._update_cache_after_submit(results)
+        # 用所有 flag 的结果共同刷新缓存，避免被某个 flag 判对后其他 flag 再重复提交。
+        merged_results = [item for _, results in flag_results for item in results]
+        self._update_cache_after_submit(merged_results)
         await self._refresh_nonces(client, account)
-        await self._reply(self._format_results(results))
+        await self._reply(self._format_multi_flag_results(flag_results))
+
+    @staticmethod
+    def _extract_flags(message: str) -> list[str]:
+        """提取消息中所有 ISCC{...} flag，保序去重。"""
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for flag in re.findall(FLAG_PATTERN, message):
+            if flag in seen:
+                continue
+            seen.add(flag)
+            ordered.append(flag)
+        return ordered
 
     async def _resolve_unsolved_ids(
         self, client: ISCCClient
@@ -352,12 +374,51 @@ class PrivateMessageHandler:
             lines.append(f"{item.track} #{item.challenge_id}: {item.message}")
         return "\n".join(lines)
 
+    def _format_multi_flag_results(
+        self, flag_results: list[tuple[str, list[SubmitResult]]]
+    ) -> str:
+        if not flag_results:
+            return "ISCC 提交完成：未识别到有效 flag。"
+
+        if len(flag_results) == 1:
+            flag, results = flag_results[0]
+            body = self._format_results(results)
+            return f"flag：{flag}\n{body}"
+
+        all_results = [item for _, results in flag_results for item in results]
+        total = len(all_results)
+        accepted = sum(1 for item in all_results if item.status == "1")
+        already = sum(1 for item in all_results if item.status == "2")
+        failed = total - accepted - already
+
+        lines = [
+            f"ISCC 批量提交完成（共 {len(flag_results)} 个 flag）",
+            f"合计提交：{total} 题",
+            f"成功：{accepted} 题",
+            f"已解决：{already} 题",
+            f"失败或跳过：{failed} 题",
+        ]
+        for flag, results in flag_results:
+            if not results:
+                lines.append(f"\n[{flag}] 当前没有未解决题目。")
+                continue
+            flag_accepted = sum(1 for item in results if item.status == "1")
+            flag_already = sum(1 for item in results if item.status == "2")
+            flag_failed = len(results) - flag_accepted - flag_already
+            lines.append(
+                f"\n[{flag}] 提交 {len(results)} 题，"
+                f"成功 {flag_accepted}，已解决 {flag_already}，失败 {flag_failed}"
+            )
+            for item in results:
+                lines.append(f"  {item.track} #{item.challenge_id}: {item.message}")
+        return "\n".join(lines)
+
     def _help_text(self) -> str:
         return (
             "ISCC 自动提交与擂台赛监控帮助\n"
             "iscc：系统管理员开关模块\n"
             "iscc配置 <账号> <密码>：登录并保存账号、密码、session\n"
-            "ISCC{xxxxx}：消息中包含该形式即会被识别为 flag，自动提交到练武题和擂台题所有未解题目\n"
+            "ISCC{xxxxx}：消息中包含一个或多个该形式即会被识别为 flag，多个 flag 会并发提交到所有未解题目\n"
             f"{SESSION_COMMAND}：查询当前 ISCC session\n"
             f"{NONCE_COMMAND}：查询当前练武题和擂台题 nonce\n"
             f"{REFRESH_COMMAND}：立即刷新练武题/擂台题未解题目缓存\n"

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -78,8 +78,9 @@ class PrivateMessageHandler:
             if self.raw_message == MONITOR_CHECK_COMMAND:
                 await self._handle_monitor_check()
                 return
-            if re.fullmatch(FLAG_PATTERN, self.raw_message):
-                await self._handle_submit_flag()
+            flag_match = re.search(FLAG_PATTERN, self.raw_message)
+            if flag_match:
+                await self._handle_submit_flag(flag_match.group(0))
         except Exception as e:
             logger.error(f"[{MODULE_NAME}]处理私聊消息失败: {e}")
             await self._reply(f"ISCC 自动提交处理失败：{e}")
@@ -127,21 +128,21 @@ class PrivateMessageHandler:
             msg_lines.append(f"未解题缓存建立失败：{err}")
         await self._reply("\n".join(msg_lines))
 
-    async def _handle_submit_flag(self):
+    async def _handle_submit_flag(self, flag: str):
         with DataManager() as dm:
             account = dm.get_account(self.user_id)
         if not account:
             await self._reply("尚未配置 ISCC 账号，请先发送：iscc配置 <账号> <密码>")
             return
 
-        await self._reply("已开始提交 flag，请等待结果。")
+        await self._reply(f"已识别到 flag：{flag}\n已开始提交，请等待结果。")
         client = await self._ensure_client(account)
 
         # 优先用缓存；任一赛道缺缓存时，现场拉一次并落库，保证结果准。
         prefetched = await self._resolve_unsolved_ids(client)
 
         results = await client.submit_flag_to_unsolved(
-            self.raw_message, prefetched_ids=prefetched
+            flag, prefetched_ids=prefetched
         )
         await self._save_session(client.session_cookie)
         self._update_cache_after_submit(results)
@@ -356,7 +357,7 @@ class PrivateMessageHandler:
             "ISCC 自动提交与擂台赛监控帮助\n"
             "iscc：系统管理员开关模块\n"
             "iscc配置 <账号> <密码>：登录并保存账号、密码、session\n"
-            "ISCC{xxxxx}：提交 flag 到练武题和擂台题所有未解题目\n"
+            "ISCC{xxxxx}：消息中包含该形式即会被识别为 flag，自动提交到练武题和擂台题所有未解题目\n"
             f"{SESSION_COMMAND}：查询当前 ISCC session\n"
             f"{NONCE_COMMAND}：查询当前练武题和擂台题 nonce\n"
             f"{REFRESH_COMMAND}：立即刷新练武题/擂台题未解题目缓存\n"

--- a/app/modules/ISCCSubmit/handlers/iscc_client.py
+++ b/app/modules/ISCCSubmit/handlers/iscc_client.py
@@ -221,15 +221,34 @@ class ISCCClient:
         flag: str,
         prefetched_ids: dict[str, list[int]] | None = None,
     ) -> list[SubmitResult]:
-        """对当前所有未解题目提交 flag。
+        """对当前所有未解题目提交单个 flag。
 
         - `prefetched_ids` 传入 `{"练武题": [...], "擂台题": [...]}` 时，直接使用该列表，
           不再实时拉取。缓存未命中的赛道会回退到实时拉取（保持旧逻辑兼容）。
         """
+        grouped = await self.submit_flags_to_unsolved([flag], prefetched_ids)
+        # 保持老调用方签名：返回单个 flag 的结果列表。
+        return grouped[0][1] if grouped else []
+
+    async def submit_flags_to_unsolved(
+        self,
+        flags: list[str],
+        prefetched_ids: dict[str, list[int]] | None = None,
+    ) -> list[tuple[str, list[SubmitResult]]]:
+        """对当前所有未解题目并发提交一批 flag。
+
+        - 拿到"哪些题未解"只做一次（同一 session 下 prefetched 缺失的赛道才补拉）。
+        - 各 flag 之间 `asyncio.gather` 并发；同一 flag 内部仍串行遍历题目，避免触发
+          平台"提交过快"（status=3）与 nonce 冲突。
+        - 返回值保持与 flags 同序：`[(flag, [SubmitResult, ...]), ...]`。
+        """
         prefetched_ids = prefetched_ids or {}
+        if not flags:
+            return []
+
         async with self._operation_session():
             contexts: list[ChallengeContext] = []
-            errors: list[SubmitResult] = []
+            shared_errors: list[SubmitResult] = []
 
             for track in (REGULAR_TRACK, ARENA_TRACK):
                 ids = prefetched_ids.get(track)
@@ -244,13 +263,21 @@ class ISCCClient:
                     else:
                         contexts.append(await self._arena_context())
                 except Exception as e:
-                    errors.append(SubmitResult(track, 0, "error", f"获取题目失败：{e}"))
+                    shared_errors.append(SubmitResult(track, 0, "error", f"获取题目失败：{e}"))
 
-            results: list[SubmitResult] = []
-            for context in contexts:
-                for challenge_id in context.challenge_ids:
-                    results.append(await self._submit_challenge(context, challenge_id, flag))
-            return [*errors, *results]
+            async def submit_one(flag: str) -> list[SubmitResult]:
+                results: list[SubmitResult] = []
+                for context in contexts:
+                    for challenge_id in context.challenge_ids:
+                        results.append(
+                            await self._submit_challenge(context, challenge_id, flag)
+                        )
+                return [*shared_errors, *results]
+
+            per_flag_results = await asyncio.gather(
+                *(submit_one(flag) for flag in flags)
+            )
+            return list(zip(flags, per_flag_results))
 
     async def fetch_unsolved_ids(self) -> dict[str, list[int]]:
         """拉取当前账号在两个赛道上的未解题 id，返回 `{"练武题": [...], "擂台题": [...]}`。

--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -1,5 +1,10 @@
 services:
   w1ndysbot:
+    # 远程服务器按实际源码本地构建镜像，避免在本地跨架构打包后再加载。
+    # 从 /opt/w1ndysbot 目录构建，Dockerfile 位于 build context 根。
+    build:
+      context: /opt/w1ndysbot
+      dockerfile: Dockerfile
     image: ${BOT_IMAGE:-w1ndysbot:latest}
     container_name: w1ndysbot
     restart: unless-stopped


### PR DESCRIPTION
## 概要

- 重构 `task deploy` 流程：本地不再打包镜像，改为同步源码到目标服务器，再在远程执行 `docker build` 与 `docker compose up`，避免本地与服务器架构不一致带来的问题。
- 远程构建时显式注明国内镜像源（apt 使用清华源，PyPI 使用清华 PyPI 镜像），加快依赖安装速度。
- 修改 `ISCCSubmit` 模块的 flag 提取规则，由完整匹配 `^ISCC{...}$` 改为正则在消息中搜索 `ISCC{...}` 子串，提高对前后文混入的容错。

## 改动文件

- `Taskfile.yml`：`deploy` 任务流程改为 rsync 上传 + 远程 build/run，移除本地打包步骤。
- `Dockerfile`：在 apt 与 uv/pip 中接入国内镜像源参数，便于远程构建提速。
- `deploy/compose.prod.yml`：`w1ndysbot` 服务改为按需构建本地源码。
- `app/modules/ISCCSubmit/__init__.py`：`FLAG_PATTERN` 改为非锚定的 `ISCC\{[^{}]+\}` 子串匹配。
- `app/modules/ISCCSubmit/handlers/handle_message_private.py`：使用 `re.search` 抽取 flag，原文里只要包含 `ISCC{...}` 就能识别提交。

## 验证

- `uv run python -m compileall app`