### PR TITLE
fix(deploy): 避免容器名冲突并消除 network 归属 warning

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,11 +58,19 @@ tasks:
           -e "ssh -p {{.PORT}}" \
           ./ {{.USER}}@{{.HOST}}:{{.DIR}}/
       # 3) 在远程服务器构建镜像并重启 bot；env 文件首次部署时从样例拷贝
+      #    - 固定 compose project name 为 w1ndysbot，避免跟历史上按 deploy/ 目录名推断出的 project（deploy）不一致，
+      #      导致同名容器被视为"外部容器"而触发 name 冲突。
+      #    - 兜底清理同名旧容器：历史遗留或手动 run 的容器不归任何 compose project 管，
+      #      `up --force-recreate` 识别不到，只能显式删掉后再拉起。
       - |
         ssh -p {{.PORT}} {{.USER}}@{{.HOST}} "cd {{.DIR}} && \
           if [ ! -f app/.env ]; then cp deploy/.env.example app/.env; fi && \
-          BOT_IMAGE={{.BOT_IMAGE}} docker compose -f deploy/compose.prod.yml build w1ndysbot && \
-          BOT_IMAGE={{.BOT_IMAGE}} docker compose -f deploy/compose.prod.yml up -d --no-deps --force-recreate w1ndysbot && \
+          docker network inspect w1ndysbot >/dev/null 2>&1 || docker network create w1ndysbot && \
+          if [ -n \"\$(docker ps -aq --filter name=^/w1ndysbot\$)\" ]; then \
+            docker rm -f w1ndysbot; \
+          fi && \
+          BOT_IMAGE={{.BOT_IMAGE}} docker compose -p w1ndysbot -f deploy/compose.prod.yml build w1ndysbot && \
+          BOT_IMAGE={{.BOT_IMAGE}} docker compose -p w1ndysbot -f deploy/compose.prod.yml up -d --no-deps --force-recreate w1ndysbot && \
           docker image prune -f"
 
   prod:up:

--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -38,3 +38,7 @@ services:
 networks:
   w1ndysbot:
     name: w1ndysbot
+    # 声明为外部网络：网络生命周期独立于 compose project，避免因 project 归属
+    # 不一致（label `com.docker.compose.project` 不匹配）产生 warning 与重建风险。
+    # 部署脚本会在 up 前先确保网络存在（docker network create w1ndysbot）。
+    external: true


### PR DESCRIPTION
## 背景

部署时报错：

```
Container w1ndysbot  Error response from daemon: Conflict.
The container name "/w1ndysbot" is already in use by container "46e109a6...".
You have to remove (or rename) that container to be able to reuse that name.
```

且伴随 warning：

```
a network with name w1ndysbot exists but was not created for project "deploy".
Set `external: true` to use an existing network
```

## 根因

- compose 把 project name 按执行目录推断成了 `deploy`，旧容器是另一个 project 创建的
- `container_name: w1ndysbot` 硬写死，Docker 直接按名字判冲突
- `--force-recreate` 只接管当前 project 下的容器，管不到这些"外部"容器
- 网络 `w1ndysbot` 生命周期独立，但 compose 没声明 `external`，每次部署都 warning

## 修复

**Taskfile.yml**
- `docker compose -p w1ndysbot`：显式固定 project name，避免被目录名带歪
- up 前 `docker ps -aq --filter name=^/w1ndysbot$` 兜底清理同名遗留容器
- `docker network create w1ndysbot`：幂等创建外部网络

**deploy/compose.prod.yml**
- `networks.w1ndysbot.external: true`：网络归外部管理，消除 warning

## 验证

- `python3 -c "import yaml; yaml.safe_load(...)"` 两个 YAML 文件语法 OK
- 逻辑自验：
  - 已有容器 → 兜底清理分支命中，`docker rm -f` 后 `up` 可正常创建
  - 已有网络 → `docker network inspect` 成功，跳过创建
  - 全新环境 → 创建网络、无遗留容器，直接 build + up