### PR TITLE
fix(iscc): decode escaped flag text before submit

### DIFF
--- a/.monkeycode/MEMORY.md
+++ b/.monkeycode/MEMORY.md
@@ -47,3 +47,11 @@ Agent 在任务执行过程中发现的条目应遵循以下格式：
   - `app/handle_events.py` 会动态加载 `app/modules/*/main.py`，模块需要在 `__init__.py` 中声明 `MODULE_ENABLED`、`MODULE_NAME`、`SWITCH_NAME` 等元信息。
   - 群开关命令通常在模块的 `handlers/handle_message_group.py` 内处理，使用 `handle_module_group_switch` 和 `is_group_switch_on` 控制模块是否响应群消息。
   - 模块菜单命令通过 `SWITCH_NAME + MENU_COMMAND` 触发，并由 `MenuManager.get_module_commands_text(MODULE_NAME)` 生成说明文本。
+
+[ISCC 提交 flag 的实体解码约定]
+- Date: 2026-05-13
+- Context: Agent 在修复 ISCCSubmit 提交异常时发现
+- Category: 代码模式
+- Instructions:
+  - `ISCCSubmit` 模块在从消息中提取 flag 以后，需要先做 HTML 实体解码，再进入后续提交流程。
+  - 私聊消息里的 `&amp;` 之类实体会被转成原始字符后再提交，避免把编码后的字符串直接发送到 ISCC 平台。

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -1,3 +1,4 @@
+import html
 import re
 
 from api.message import send_private_msg
@@ -165,6 +166,7 @@ class PrivateMessageHandler:
         seen: set[str] = set()
         ordered: list[str] = []
         for flag in re.findall(FLAG_PATTERN, message):
+            flag = html.unescape(flag)
             if flag in seen:
                 continue
             seen.add(flag)


### PR DESCRIPTION
## Summary
- Decode HTML entities in extracted ISCC flags before submission so escaped characters like `&amp;` are restored to `&`.
- Record the ISCC flag entity decoding behavior in project memory for future module changes.

## Verification
- `python3 -m compileall app`