### PR TITLE
fix(ISCCSubmit): 补全缓存刷新和提交结果题目信息

### DIFF
--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -265,15 +265,27 @@ class PrivateMessageHandler:
             with DataManager() as dm:
                 regular_meta = dm.get_unsolved_meta(self.user_id, REGULAR_TRACK)
                 arena_meta = dm.get_unsolved_meta(self.user_id, ARENA_TRACK)
+                regular_ids = dm.get_unsolved_ids(self.user_id, REGULAR_TRACK) or []
+                arena_ids = dm.get_unsolved_ids(self.user_id, ARENA_TRACK) or []
+                regular_names = dm.get_unsolved_names(self.user_id, REGULAR_TRACK)
+                arena_names = dm.get_unsolved_names(self.user_id, ARENA_TRACK)
             ts = (
                 regular_meta and regular_meta.get("updated_at")
             ) or (arena_meta and arena_meta.get("updated_at")) or "刚刚"
-            await self._reply(
-                "未解题缓存已刷新\n"
-                f"练武题：{regular_n} 题未解\n"
-                f"擂台题：{arena_n} 题未解\n"
-                f"更新时间：{ts}"
-            )
+            lines = [
+                "未解题缓存已刷新",
+                f"练武题：{regular_n} 题未解",
+                f"擂台题：{arena_n} 题未解",
+                f"更新时间：{ts}",
+            ]
+            if regular_ids or arena_ids:
+                lines.append("")
+                lines.append("未解题目：")
+                for cid in regular_ids:
+                    lines.append(f"- {self._format_unsolved_line(REGULAR_TRACK, cid, regular_names.get(cid, ''))}")
+                for cid in arena_ids:
+                    lines.append(f"- {self._format_unsolved_line(ARENA_TRACK, cid, arena_names.get(cid, ''))}")
+            await self._reply("\n".join(lines))
         else:
             await self._reply(f"刷新未解题缓存失败：{err}")
 
@@ -396,8 +408,9 @@ class PrivateMessageHandler:
 
     @staticmethod
     def _format_result_target(item: SubmitResult) -> str:
-        name = f" {item.challenge_name}" if item.challenge_name else ""
-        return f"{item.track} #{item.challenge_id}{name}"
+        if item.challenge_name:
+            return f"{item.track} {item.challenge_name} #{item.challenge_id}"
+        return f"{item.track} #{item.challenge_id}"
 
     def _format_multi_flag_results(
         self, flag_results: list[tuple[str, list[SubmitResult]]]
@@ -437,6 +450,12 @@ class PrivateMessageHandler:
             for item in results:
                 lines.append(f"  {self._format_result_target(item)}: {item.message}")
         return "\n".join(lines)
+
+    @staticmethod
+    def _format_unsolved_line(track: str, challenge_id: int, challenge_name: str) -> str:
+        if challenge_name:
+            return f"{track} {challenge_name} #{challenge_id}"
+        return f"{track} #{challenge_id}"
 
     def _help_text(self) -> str:
         return (

--- a/app/modules/ISCCSubmit/handlers/iscc_client.py
+++ b/app/modules/ISCCSubmit/handlers/iscc_client.py
@@ -353,12 +353,10 @@ class ISCCClient:
     async def _regular_challenges(self) -> dict[int, str]:
         data = await self._request_json("GET", "/chals", referer=f"{self.base_url}/challenges")
         challenges: dict[int, str] = {}
-        # /chals 返回结构常见为 {"game": [...]} 或 {"challenges": [...]}，做兼容
-        for key in ("game", "challenges"):
-            for item in data.get(key, []) or []:
-                cid = item.get("id") if isinstance(item, dict) else None
-                if str(cid).isdigit():
-                    challenges[int(cid)] = self._extract_challenge_name(item)
+        for item in self._iter_challenge_items(data):
+            cid = item.get("id") if isinstance(item, dict) else None
+            if str(cid).isdigit():
+                challenges[int(cid)] = self._extract_challenge_name(item)
         return challenges
 
     async def _arena_challenge_ids(self) -> set[int]:
@@ -367,15 +365,45 @@ class ISCCClient:
     async def _arena_challenges(self) -> dict[int, str]:
         data = await self._request_json("GET", "/arenas", referer=f"{self.base_url}/arena")
         challenges: dict[int, str] = {}
-        for item in data.get("game", []) or []:
+        for item in self._iter_challenge_items(data):
             cid = item.get("id") if isinstance(item, dict) else None
             if str(cid).isdigit():
                 challenges[int(cid)] = self._extract_challenge_name(item)
         return challenges
 
+    def _iter_challenge_items(self, value):
+        if isinstance(value, dict):
+            if self._looks_like_challenge_item(value):
+                yield value
+            for child in value.values():
+                yield from self._iter_challenge_items(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from self._iter_challenge_items(child)
+
+    def _looks_like_challenge_item(self, item: dict) -> bool:
+        if not str(item.get("id", "")).isdigit() or not self._extract_challenge_name(item):
+            return False
+        if not any(isinstance(value, (dict, list)) for value in item.values()):
+            return True
+        return bool(
+            {
+                "category",
+                "type",
+                "solves",
+                "solved_by_me",
+                "max_attempts",
+                "files",
+                "tags",
+                "description",
+                "connection_info",
+            }
+            & set(item)
+        )
+
     @staticmethod
     def _extract_challenge_name(item: dict) -> str:
-        for key in ("name", "title", "chal_name", "challenge", "value"):
+        for key in ("name", "title", "chal_name", "challenge", "value", "题目名称", "题目"):
             value = item.get(key)
             if value:
                 return str(value).strip()


### PR DESCRIPTION
## Summary
- 在 ISCC 提交结果中同时展示题目名称和 ID，便于区分同赛道题目。
- 在未解题缓存刷新回执中追加未解题目明细，包含赛道、题目名称和 ID。
- 增强 `/chals` 与 `/arenas` 题目列表解析，兼容嵌套 JSON 结构中的题目条目。

## Verification
- `python3 -m compileall app`
- `git diff --check`