### PR TITLE
feat(ISCCSubmit): 支持按方向批量提交 flag

### DIFF
--- a/app/modules/ISCCSubmit/__init__.py
+++ b/app/modules/ISCCSubmit/__init__.py
@@ -21,7 +21,10 @@ NONCE_COMMAND = "isccnonce"
 REFRESH_COMMAND = "iscc刷新"
 # 不再要求消息以 ISCC{ 开头/结尾，只要消息里包含一段 ISCC{...} 就识别成 flag 提交，
 # 提高对客户端转发、引用、上下文带前后缀场景的容错。
-FLAG_PATTERN = r"ISCC\{[^{}]+\}"
+# 同时允许在 flag 后面跟一个空白 + 方向（题目分类），用于按方向批量提交，例如
+# `ISCC{xxxx} web` 表示该 flag 仅提交到 web 方向的未解题目。方向匹配在客户端
+# 侧不区分大小写，并采用子串模糊匹配。
+FLAG_PATTERN = r"ISCC\{[^{}]+\}(?:[ \t]+([^\s{}]+))?"
 
 # 每日自动刷新 session 的北京时间（24 小时制）
 DAILY_REFRESH_HOUR = 7
@@ -38,6 +41,7 @@ COMMANDS = {
     SWITCH_NAME: "系统管理员开关 ISCC 自动提交与擂台赛监控模块",
     CONFIG_COMMAND: "配置 ISCC 账号，用法：iscc配置 <账号> <密码>",
     "ISCC{xxxxx}": "提交 flag 到 ISCC 平台未解题目（消息中可包含多个 ISCC{...}，会并发提交，无需独立成行）",
+    "ISCC{xxxxx} <方向>": "在 flag 后跟空格加方向（如 web、misc），仅向匹配方向的未解题目批量提交，方向不区分大小写并支持模糊匹配",
     SESSION_COMMAND: "查询当前 ISCC session",
     NONCE_COMMAND: "查询当前 ISCC 练武题和擂台题 nonce",
     REFRESH_COMMAND: "立即刷新练武题/擂台题未解题目缓存",

--- a/app/modules/ISCCSubmit/__init__.py
+++ b/app/modules/ISCCSubmit/__init__.py
@@ -24,7 +24,9 @@ REFRESH_COMMAND = "iscc刷新"
 # 同时允许在 flag 后面跟一个空白 + 方向（题目分类），用于按方向批量提交，例如
 # `ISCC{xxxx} web` 表示该 flag 仅提交到 web 方向的未解题目。方向匹配在客户端
 # 侧不区分大小写，并采用子串模糊匹配。
-FLAG_PATTERN = r"ISCC\{[^{}]+\}(?:[ \t]+([^\s{}]+))?"
+# 方向 token 通过负向先行断言排除掉下一段 `ISCC{...}`，避免把"下一条 flag"误吞为
+# 上一条 flag 的方向。
+FLAG_PATTERN = r"ISCC\{[^{}]+\}(?:[ \t]+(?!ISCC\{)([^\s{}]+))?"
 
 # 每日自动刷新 session 的北京时间（24 小时制）
 DAILY_REFRESH_HOUR = 7

--- a/app/modules/ISCCSubmit/handlers/data_manager.py
+++ b/app/modules/ISCCSubmit/handlers/data_manager.py
@@ -88,12 +88,14 @@ class DataManager:
                 track TEXT NOT NULL,
                 ids TEXT NOT NULL DEFAULT '',
                 names TEXT NOT NULL DEFAULT '{}',
+                categories TEXT NOT NULL DEFAULT '{}',
                 updated_at TEXT NOT NULL,
                 PRIMARY KEY (user_id, track)
             )
             """
         )
         self._ensure_unsolved_cache_names_column()
+        self._ensure_unsolved_cache_categories_column()
         self.conn.commit()
 
     def _ensure_unsolved_cache_names_column(self):
@@ -102,6 +104,14 @@ class DataManager:
         if "names" not in columns:
             self.cursor.execute(
                 "ALTER TABLE iscc_unsolved_cache ADD COLUMN names TEXT NOT NULL DEFAULT '{}'"
+            )
+
+    def _ensure_unsolved_cache_categories_column(self):
+        self.cursor.execute("PRAGMA table_info(iscc_unsolved_cache)")
+        columns = {row["name"] for row in self.cursor.fetchall()}
+        if "categories" not in columns:
+            self.cursor.execute(
+                "ALTER TABLE iscc_unsolved_cache ADD COLUMN categories TEXT NOT NULL DEFAULT '{}'"
             )
 
     def __enter__(self):
@@ -257,6 +267,27 @@ class DataManager:
             if str(cid).isdigit() and name
         }
 
+    def get_unsolved_categories(self, user_id: str, track: str) -> dict[int, str]:
+        """读取未解题缓存中的题目方向映射。旧缓存无方向时返回空 dict。"""
+        self.cursor.execute(
+            """
+            SELECT categories FROM iscc_unsolved_cache WHERE user_id = ? AND track = ?
+            """,
+            (user_id, track),
+        )
+        row = self.cursor.fetchone()
+        if row is None:
+            return {}
+        try:
+            raw = json.loads(row["categories"] or "{}")
+        except (TypeError, ValueError):
+            return {}
+        return {
+            int(cid): str(category)
+            for cid, category in raw.items()
+            if str(cid).isdigit() and category
+        }
+
     def get_unsolved_meta(self, user_id: str, track: str) -> Optional[dict]:
         self.cursor.execute(
             """
@@ -274,6 +305,7 @@ class DataManager:
         track: str,
         ids: list[int],
         names: dict[int, str] | None = None,
+        categories: dict[int, str] | None = None,
     ):
         """覆盖式保存未解题缓存。"""
         joined = ",".join(str(int(x)) for x in ids)
@@ -281,16 +313,25 @@ class DataManager:
             {str(int(cid)): str(name) for cid, name in (names or {}).items() if name},
             ensure_ascii=False,
         )
+        categories_payload = json.dumps(
+            {
+                str(int(cid)): str(category)
+                for cid, category in (categories or {}).items()
+                if category
+            },
+            ensure_ascii=False,
+        )
         self.cursor.execute(
             """
-            INSERT INTO iscc_unsolved_cache (user_id, track, ids, names, updated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO iscc_unsolved_cache (user_id, track, ids, names, categories, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(user_id, track)
             DO UPDATE SET ids = excluded.ids,
                           names = excluded.names,
+                          categories = excluded.categories,
                           updated_at = excluded.updated_at
             """,
-            (user_id, track, joined, names_payload, self._now_text()),
+            (user_id, track, joined, names_payload, categories_payload, self._now_text()),
         )
 
     def remove_unsolved_ids(self, user_id: str, track: str, removed_ids: list[int]):
@@ -304,11 +345,13 @@ class DataManager:
         if remaining == current:
             return
         names = self.get_unsolved_names(user_id, track)
+        categories = self.get_unsolved_categories(user_id, track)
         self.save_unsolved_ids(
             user_id,
             track,
             remaining,
             {cid: names[cid] for cid in remaining if cid in names},
+            {cid: categories[cid] for cid in remaining if cid in categories},
         )
 
     # ==================== 擂台赛监控 ====================

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -161,6 +161,31 @@ class PrivateMessageHandler:
         # 优先用缓存；任一赛道缺缓存时，现场拉一次并落库，保证结果准。
         prefetched, prefetched_names, prefetched_categories = await self._resolve_unsolved_ids(client)
 
+        # 若用户带了方向过滤但缓存里没有任何 category（旧缓存未升级或拉取失败），
+        # 主动再拉一次明细，避免方向过滤把所有题目当成不匹配丢掉。
+        needs_categories = any(cat for _, cat in flags)
+        has_any_category = any(prefetched_categories.get(track) for track in prefetched_categories)
+        if needs_categories and not has_any_category:
+            try:
+                fresh = await client.fetch_unsolved_challenges_detailed()
+            except Exception as e:
+                logger.warning(f"[{MODULE_NAME}]按方向提交前补拉题目分类失败: {e}")
+            else:
+                prefetched = {}
+                prefetched_names = {}
+                prefetched_categories = {}
+                with DataManager() as dm:
+                    for track in (REGULAR_TRACK, ARENA_TRACK):
+                        track_data = fresh.get(track, {})
+                        names = track_data.get("names", {})
+                        categories = track_data.get("categories", {})
+                        prefetched_names[track] = names
+                        prefetched_categories[track] = categories
+                        prefetched[track] = list(names)
+                        dm.save_unsolved_ids(
+                            self.user_id, track, list(names), names, categories
+                        )
+
         flag_results = await client.submit_flags_to_unsolved(
             flags,
             prefetched_ids=prefetched,

--- a/app/modules/ISCCSubmit/handlers/handle_message_private.py
+++ b/app/modules/ISCCSubmit/handlers/handle_message_private.py
@@ -129,7 +129,7 @@ class PrivateMessageHandler:
             msg_lines.append(f"未解题缓存建立失败：{err}")
         await self._reply("\n".join(msg_lines))
 
-    async def _handle_submit_flag(self, flags: list[str]):
+    async def _handle_submit_flag(self, flags: list[tuple[str, str | None]]):
         with DataManager() as dm:
             account = dm.get_account(self.user_id)
         if not account:
@@ -137,9 +137,20 @@ class PrivateMessageHandler:
             return
 
         if len(flags) == 1:
-            notice = f"已识别到 flag：{flags[0]}\n已开始提交，请等待结果。"
+            flag_text, cat_filter = flags[0]
+            if cat_filter:
+                notice = (
+                    f"已识别到 flag：{flag_text}\n"
+                    f"方向限定：{cat_filter}（不区分大小写、模糊匹配）\n"
+                    "已开始提交，请等待结果。"
+                )
+            else:
+                notice = f"已识别到 flag：{flag_text}\n已开始提交，请等待结果。"
         else:
-            bullet = "\n".join(f"- {flag}" for flag in flags)
+            bullet = "\n".join(
+                f"- {flag_text}" + (f"（方向：{cat}）" if cat else "")
+                for flag_text, cat in flags
+            )
             notice = (
                 f"已识别到 {len(flags)} 个 flag，将并发提交：\n{bullet}\n请等待结果。"
             )
@@ -148,37 +159,55 @@ class PrivateMessageHandler:
         client = await self._ensure_client(account)
 
         # 优先用缓存；任一赛道缺缓存时，现场拉一次并落库，保证结果准。
-        prefetched, prefetched_names = await self._resolve_unsolved_ids(client)
+        prefetched, prefetched_names, prefetched_categories = await self._resolve_unsolved_ids(client)
 
         flag_results = await client.submit_flags_to_unsolved(
-            flags, prefetched_ids=prefetched, prefetched_names=prefetched_names
+            flags,
+            prefetched_ids=prefetched,
+            prefetched_names=prefetched_names,
+            prefetched_categories=prefetched_categories,
         )
         await self._save_session(client.session_cookie)
         # 用所有 flag 的结果共同刷新缓存，避免被某个 flag 判对后其他 flag 再重复提交。
         merged_results = [item for _, results in flag_results for item in results]
         self._update_cache_after_submit(merged_results)
         await self._refresh_nonces(client, account)
-        await self._reply(self._format_multi_flag_results(flag_results))
+        await self._reply(self._format_multi_flag_results(flag_results, flags))
 
     @staticmethod
-    def _extract_flags(message: str) -> list[str]:
-        """提取消息中所有 ISCC{...} flag，保序去重。"""
-        seen: set[str] = set()
-        ordered: list[str] = []
-        for flag in re.findall(FLAG_PATTERN, message):
-            flag = html.unescape(flag)
-            if flag in seen:
+    def _extract_flags(message: str) -> list[tuple[str, str | None]]:
+        """提取消息中所有 ISCC{...} flag 与可选的方向限定，保序去重。
+
+        - 单条消息允许多次出现 `ISCC{...}` 或 `ISCC{...} <方向>`，按出现顺序返回。
+        - 去重 key 为 (flag, category_filter_lower)，避免同一 flag 同一方向重复提交，
+          但同一 flag 不同方向（或一带方向一不带）视为两次独立提交。
+        """
+        seen: set[tuple[str, str]] = set()
+        ordered: list[tuple[str, str | None]] = []
+        for match in re.finditer(FLAG_PATTERN, message):
+            # FLAG_PATTERN 形如：ISCC\{[^{}]+\}(?:[ \t]+([^\s{}]+))?
+            # group(1) 仅捕获方向 token；flag 主体需通过 `ISCC{...}` 子模式重新定位。
+            flag_match = re.match(r"ISCC\{[^{}]+\}", match.group(0))
+            if not flag_match:
                 continue
-            seen.add(flag)
-            ordered.append(flag)
+            flag_body = html.unescape(flag_match.group(0))
+            cat_token = match.group(1)
+            cat_filter = html.unescape(cat_token).strip() if cat_token else ""
+            cat_filter = cat_filter or None
+            key = (flag_body, (cat_filter or "").lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append((flag_body, cat_filter))
         return ordered
 
     async def _resolve_unsolved_ids(
         self, client: ISCCClient
-    ) -> tuple[dict[str, list[int]], dict[str, dict[int, str]]]:
-        """读取未解题缓存；缓存缺失时实时拉一次并落库。出错时返回空 dict 走兜底分支。"""
+    ) -> tuple[dict[str, list[int]], dict[str, dict[int, str]], dict[str, dict[int, str]]]:
+        """读取未解题缓存（id/name/category）；缓存缺失时实时拉一次并落库。出错时返回空 dict 走兜底分支。"""
         prefetched: dict[str, list[int]] = {}
         prefetched_names: dict[str, dict[int, str]] = {}
+        prefetched_categories: dict[str, dict[int, str]] = {}
         missing_tracks: list[str] = []
         with DataManager() as dm:
             for track in (REGULAR_TRACK, ARENA_TRACK):
@@ -188,30 +217,36 @@ class PrivateMessageHandler:
                 else:
                     prefetched[track] = ids
                     prefetched_names[track] = dm.get_unsolved_names(self.user_id, track)
+                    prefetched_categories[track] = dm.get_unsolved_categories(self.user_id, track)
 
         if not missing_tracks:
-            return prefetched, prefetched_names
+            return prefetched, prefetched_names, prefetched_categories
 
         try:
-            fresh = await client.fetch_unsolved_challenges()
+            fresh = await client.fetch_unsolved_challenges_detailed()
         except Exception as e:
             logger.warning(f"[{MODULE_NAME}]flag 提交前拉取未解题失败: {e}")
             # 让 submit_flag_to_unsolved 自己走兜底的实时拉路径，同时给已有缓存留着
-            return prefetched, prefetched_names
+            return prefetched, prefetched_names, prefetched_categories
 
         with DataManager() as dm:
             for track in (REGULAR_TRACK, ARENA_TRACK):
                 if track in fresh:
+                    names = fresh[track].get("names", {})
+                    categories = fresh[track].get("categories", {})
                     dm.save_unsolved_ids(
                         self.user_id,
                         track,
-                        list(fresh[track]),
-                        fresh[track],
+                        list(names),
+                        names,
+                        categories,
                     )
         for track in missing_tracks:
-            prefetched_names[track] = fresh.get(track, {})
+            track_data = fresh.get(track, {})
+            prefetched_names[track] = track_data.get("names", {})
+            prefetched_categories[track] = track_data.get("categories", {})
             prefetched[track] = list(prefetched_names[track])
-        return prefetched, prefetched_names
+        return prefetched, prefetched_names, prefetched_categories
 
     def _update_cache_after_submit(self, results: list[SubmitResult]):
         """把刚被判为"正确/已解决"的题目从未解缓存里摘掉。"""
@@ -229,27 +264,28 @@ class PrivateMessageHandler:
     async def _refresh_unsolved_cache(
         self, client: ISCCClient
     ) -> tuple[bool, int, int, str]:
-        """主动刷新未解题缓存，返回 (是否成功, 练武未解数, 擂台未解数, 错误信息)。"""
+        """主动刷新未解题缓存（id/name/category），返回 (是否成功, 练武未解数, 擂台未解数, 错误信息)。"""
         try:
-            fresh = await client.fetch_unsolved_challenges()
+            fresh = await client.fetch_unsolved_challenges_detailed()
         except Exception as e:
             logger.warning(f"[{MODULE_NAME}]刷新未解题缓存失败: {e}")
             return False, 0, 0, str(e)
         with DataManager() as dm:
-            dm.save_unsolved_ids(
-                self.user_id,
-                REGULAR_TRACK,
-                list(fresh.get(REGULAR_TRACK, {})),
-                fresh.get(REGULAR_TRACK, {}),
-            )
-            dm.save_unsolved_ids(
-                self.user_id,
-                ARENA_TRACK,
-                list(fresh.get(ARENA_TRACK, {})),
-                fresh.get(ARENA_TRACK, {}),
-            )
+            for track in (REGULAR_TRACK, ARENA_TRACK):
+                track_data = fresh.get(track, {})
+                names = track_data.get("names", {})
+                categories = track_data.get("categories", {})
+                dm.save_unsolved_ids(
+                    self.user_id,
+                    track,
+                    list(names),
+                    names,
+                    categories,
+                )
         await self._save_session(client.session_cookie)
-        return True, len(fresh.get(REGULAR_TRACK, [])), len(fresh.get(ARENA_TRACK, [])), ""
+        regular_n = len(fresh.get(REGULAR_TRACK, {}).get("names", {}))
+        arena_n = len(fresh.get(ARENA_TRACK, {}).get("names", {}))
+        return True, regular_n, arena_n, ""
 
     async def _handle_refresh_unsolved(self):
         with DataManager() as dm:
@@ -269,6 +305,8 @@ class PrivateMessageHandler:
                 arena_ids = dm.get_unsolved_ids(self.user_id, ARENA_TRACK) or []
                 regular_names = dm.get_unsolved_names(self.user_id, REGULAR_TRACK)
                 arena_names = dm.get_unsolved_names(self.user_id, ARENA_TRACK)
+                regular_categories = dm.get_unsolved_categories(self.user_id, REGULAR_TRACK)
+                arena_categories = dm.get_unsolved_categories(self.user_id, ARENA_TRACK)
             ts = (
                 regular_meta and regular_meta.get("updated_at")
             ) or (arena_meta and arena_meta.get("updated_at")) or "刚刚"
@@ -282,9 +320,25 @@ class PrivateMessageHandler:
                 lines.append("")
                 lines.append("未解题目：")
                 for cid in regular_ids:
-                    lines.append(f"- {self._format_unsolved_line(REGULAR_TRACK, cid, regular_names.get(cid, ''))}")
+                    lines.append(
+                        "- "
+                        + self._format_unsolved_line(
+                            REGULAR_TRACK,
+                            cid,
+                            regular_names.get(cid, ""),
+                            regular_categories.get(cid, ""),
+                        )
+                    )
                 for cid in arena_ids:
-                    lines.append(f"- {self._format_unsolved_line(ARENA_TRACK, cid, arena_names.get(cid, ''))}")
+                    lines.append(
+                        "- "
+                        + self._format_unsolved_line(
+                            ARENA_TRACK,
+                            cid,
+                            arena_names.get(cid, ""),
+                            arena_categories.get(cid, ""),
+                        )
+                    )
             await self._reply("\n".join(lines))
         else:
             await self._reply(f"刷新未解题缓存失败：{err}")
@@ -388,8 +442,12 @@ class PrivateMessageHandler:
             dm.save_session(self.user_id, session)
         return await client.fetch_nonces()
 
-    def _format_results(self, results: list[SubmitResult]) -> str:
+    def _format_results(
+        self, results: list[SubmitResult], cat_filter: str | None = None
+    ) -> str:
         if not results:
+            if cat_filter:
+                return f"ISCC 提交完成：当前没有匹配方向「{cat_filter}」的未解题目。"
             return "ISCC 提交完成：当前没有未解决题目。"
 
         accepted = [item for item in results if item.status == "1"]
@@ -413,15 +471,29 @@ class PrivateMessageHandler:
         return f"{item.track} #{item.challenge_id}"
 
     def _format_multi_flag_results(
-        self, flag_results: list[tuple[str, list[SubmitResult]]]
+        self,
+        flag_results: list[tuple[str, list[SubmitResult]]],
+        flag_specs: list[tuple[str, str | None]] | None = None,
     ) -> str:
         if not flag_results:
             return "ISCC 提交完成：未识别到有效 flag。"
 
+        # 用原始 specs 的方向信息为每个 flag 标注；按出现顺序与 flag_results 一一对应。
+        specs = list(flag_specs or [])
+
+        def _spec_for(idx: int, flag: str) -> tuple[str, str | None]:
+            if idx < len(specs):
+                return specs[idx]
+            return flag, None
+
         if len(flag_results) == 1:
             flag, results = flag_results[0]
-            body = self._format_results(results)
-            return f"flag：{flag}\n{body}"
+            _, cat_filter = _spec_for(0, flag)
+            body = self._format_results(results, cat_filter)
+            header = f"flag：{flag}"
+            if cat_filter:
+                header += f"\n方向限定：{cat_filter}"
+            return f"{header}\n{body}"
 
         all_results = [item for _, results in flag_results for item in results]
         total = len(all_results)
@@ -436,15 +508,22 @@ class PrivateMessageHandler:
             f"已解决：{already} 题",
             f"失败或跳过：{failed} 题",
         ]
-        for flag, results in flag_results:
+        for idx, (flag, results) in enumerate(flag_results):
+            _, cat_filter = _spec_for(idx, flag)
+            tag = f"[{flag}]" + (f"（方向：{cat_filter}）" if cat_filter else "")
             if not results:
-                lines.append(f"\n[{flag}] 当前没有未解决题目。")
+                if cat_filter:
+                    lines.append(
+                        f"\n{tag} 当前没有匹配方向「{cat_filter}」的未解题目。"
+                    )
+                else:
+                    lines.append(f"\n{tag} 当前没有未解决题目。")
                 continue
             flag_accepted = sum(1 for item in results if item.status == "1")
             flag_already = sum(1 for item in results if item.status == "2")
             flag_failed = len(results) - flag_accepted - flag_already
             lines.append(
-                f"\n[{flag}] 提交 {len(results)} 题，"
+                f"\n{tag} 提交 {len(results)} 题，"
                 f"成功 {flag_accepted}，已解决 {flag_already}，失败 {flag_failed}"
             )
             for item in results:
@@ -452,10 +531,15 @@ class PrivateMessageHandler:
         return "\n".join(lines)
 
     @staticmethod
-    def _format_unsolved_line(track: str, challenge_id: int, challenge_name: str) -> str:
+    def _format_unsolved_line(
+        track: str, challenge_id: int, challenge_name: str, category: str = ""
+    ) -> str:
+        parts = [track]
         if challenge_name:
-            return f"{track} {challenge_name} #{challenge_id}"
-        return f"{track} #{challenge_id}"
+            parts.append(challenge_name)
+        parts.append(f"#{challenge_id}")
+        head = " ".join(parts)
+        return f"{head} [{category}]" if category else head
 
     def _help_text(self) -> str:
         return (
@@ -463,6 +547,7 @@ class PrivateMessageHandler:
             "iscc：系统管理员开关模块\n"
             "iscc配置 <账号> <密码>：登录并保存账号、密码、session\n"
             "ISCC{xxxxx}：消息中包含一个或多个该形式即会被识别为 flag，多个 flag 会并发提交到所有未解题目\n"
+            "ISCC{xxxxx} <方向>：flag 后跟一个空格再跟方向（如 web、misc），表示只把该 flag 提交到匹配该方向的未解题，方向不区分大小写并支持模糊匹配\n"
             f"{SESSION_COMMAND}：查询当前 ISCC session\n"
             f"{NONCE_COMMAND}：查询当前练武题和擂台题 nonce\n"
             f"{REFRESH_COMMAND}：立即刷新练武题/擂台题未解题目缓存\n"

--- a/app/modules/ISCCSubmit/handlers/handle_meta_event.py
+++ b/app/modules/ISCCSubmit/handlers/handle_meta_event.py
@@ -241,23 +241,24 @@ class MetaEventHandler:
     async def _refresh_unsolved_cache(
         self, user_id: str, client: ISCCClient
     ) -> tuple[int | None, int | None]:
-        """调用 client.fetch_unsolved_ids 并落库；失败返回 (None, None)。"""
+        """调用 client.fetch_unsolved_challenges_detailed 并落库；失败返回 (None, None)。"""
         try:
-            fresh = await client.fetch_unsolved_challenges()
+            fresh = await client.fetch_unsolved_challenges_detailed()
         except Exception as e:
             logger.warning(f"[{MODULE_NAME}]刷新未解题缓存失败: {e}")
             return None, None
         with DataManager() as dm:
-            dm.save_unsolved_ids(
-                user_id,
-                REGULAR_TRACK,
-                list(fresh.get(REGULAR_TRACK, {})),
-                fresh.get(REGULAR_TRACK, {}),
-            )
-            dm.save_unsolved_ids(
-                user_id,
-                ARENA_TRACK,
-                list(fresh.get(ARENA_TRACK, {})),
-                fresh.get(ARENA_TRACK, {}),
-            )
-        return len(fresh.get(REGULAR_TRACK, [])), len(fresh.get(ARENA_TRACK, []))
+            for track in (REGULAR_TRACK, ARENA_TRACK):
+                track_data = fresh.get(track, {})
+                names = track_data.get("names", {})
+                categories = track_data.get("categories", {})
+                dm.save_unsolved_ids(
+                    user_id,
+                    track,
+                    list(names),
+                    names,
+                    categories,
+                )
+        regular_n = len(fresh.get(REGULAR_TRACK, {}).get("names", {}))
+        arena_n = len(fresh.get(ARENA_TRACK, {}).get("names", {}))
+        return regular_n, arena_n

--- a/app/modules/ISCCSubmit/handlers/iscc_client.py
+++ b/app/modules/ISCCSubmit/handlers/iscc_client.py
@@ -28,6 +28,7 @@ class ChallengeContext:
     submit_path: str
     challenge_ids: list[int]
     challenge_names: dict[int, str] = field(default_factory=dict)
+    challenge_categories: dict[int, str] = field(default_factory=dict)
 
 
 # 赛道标签 -> (未解题提交前缀 / referer 页面)
@@ -223,24 +224,36 @@ class ISCCClient:
         flag: str,
         prefetched_ids: dict[str, list[int]] | None = None,
         prefetched_names: dict[str, dict[int, str]] | None = None,
+        prefetched_categories: dict[str, dict[int, str]] | None = None,
+        category_filter: str | None = None,
     ) -> list[SubmitResult]:
         """对当前所有未解题目提交单个 flag。
 
         - `prefetched_ids` 传入 `{"练武题": [...], "擂台题": [...]}` 时，直接使用该列表，
           不再实时拉取。缓存未命中的赛道会回退到实时拉取（保持旧逻辑兼容）。
+        - `category_filter` 不为 None 时，仅向 category 匹配该过滤条件的题目提交，
+          匹配规则在客户端侧统一处理（不区分大小写、支持子串模糊匹配）。
         """
-        grouped = await self.submit_flags_to_unsolved([flag], prefetched_ids, prefetched_names)
+        grouped = await self.submit_flags_to_unsolved(
+            [(flag, category_filter)],
+            prefetched_ids,
+            prefetched_names,
+            prefetched_categories,
+        )
         # 保持老调用方签名：返回单个 flag 的结果列表。
         return grouped[0][1] if grouped else []
 
     async def submit_flags_to_unsolved(
         self,
-        flags: list[str],
+        flags: list[str] | list[tuple[str, str | None]],
         prefetched_ids: dict[str, list[int]] | None = None,
         prefetched_names: dict[str, dict[int, str]] | None = None,
+        prefetched_categories: dict[str, dict[int, str]] | None = None,
     ) -> list[tuple[str, list[SubmitResult]]]:
         """对当前所有未解题目并发提交一批 flag。
 
+        - `flags` 既兼容老的 `list[str]`，也支持新格式 `list[tuple[str, str | None]]`，
+          后者第二项为该 flag 的方向过滤条件（None 表示不过滤，即全量提交）。
         - 拿到"哪些题未解"只做一次（同一 session 下 prefetched 缺失的赛道才补拉）。
         - 各 flag 之间 `asyncio.gather` 并发；同一 flag 内部仍串行遍历题目，避免触发
           平台"提交过快"（status=3）与 nonce 冲突。
@@ -248,8 +261,18 @@ class ISCCClient:
         """
         prefetched_ids = prefetched_ids or {}
         prefetched_names = prefetched_names or {}
+        prefetched_categories = prefetched_categories or {}
         if not flags:
             return []
+
+        # 统一成 (flag, category_filter) 形式，向后兼容旧调用方
+        normalized: list[tuple[str, str | None]] = []
+        for item in flags:
+            if isinstance(item, tuple):
+                flag_text, cat_filter = item
+                normalized.append((flag_text, cat_filter))
+            else:
+                normalized.append((item, None))
 
         async with self._operation_session():
             contexts: list[ChallengeContext] = []
@@ -264,6 +287,7 @@ class ISCCClient:
                             TRACK_SUBMIT_PATH[track],
                             sorted(set(ids)),
                             prefetched_names.get(track, {}),
+                            prefetched_categories.get(track, {}),
                         )
                     )
                     continue
@@ -275,19 +299,43 @@ class ISCCClient:
                 except Exception as e:
                     shared_errors.append(SubmitResult(track, 0, "error", f"获取题目失败：{e}"))
 
-            async def submit_one(flag: str) -> list[SubmitResult]:
+            async def submit_one(flag: str, cat_filter: str | None) -> list[SubmitResult]:
                 results: list[SubmitResult] = []
                 for context in contexts:
-                    for challenge_id in context.challenge_ids:
+                    target_ids = self._filter_by_category(context, cat_filter)
+                    for challenge_id in target_ids:
                         results.append(
                             await self._submit_challenge(context, challenge_id, flag)
                         )
                 return [*shared_errors, *results]
 
             per_flag_results = await asyncio.gather(
-                *(submit_one(flag) for flag in flags)
+                *(submit_one(flag, cat_filter) for flag, cat_filter in normalized)
             )
-            return list(zip(flags, per_flag_results))
+            return list(zip([flag for flag, _ in normalized], per_flag_results))
+
+    @staticmethod
+    def _filter_by_category(
+        context: ChallengeContext, cat_filter: str | None
+    ) -> list[int]:
+        """根据方向过滤未解题目 id，规则：不区分大小写 + 子串模糊匹配。
+
+        - `cat_filter` 为 None 或空字符串时返回全部 challenge_ids。
+        - context.challenge_categories 为空（拉取阶段未取到分类）时按"无可匹配题目"
+          处理，返回空列表，避免误把全部题目当作匹配项。
+        """
+        if not cat_filter:
+            return list(context.challenge_ids)
+        needle = cat_filter.strip().lower()
+        if not needle:
+            return list(context.challenge_ids)
+        if not context.challenge_categories:
+            return []
+        return [
+            cid
+            for cid in context.challenge_ids
+            if needle in str(context.challenge_categories.get(cid, "")).lower()
+        ]
 
     async def fetch_unsolved_ids(self) -> dict[str, list[int]]:
         """拉取当前账号在两个赛道上的未解题 id，返回 `{"练武题": [...], "擂台题": [...]}`。
@@ -320,6 +368,46 @@ class ISCCClient:
                 },
             }
 
+    async def fetch_unsolved_challenges_detailed(
+        self,
+    ) -> dict[str, dict[str, dict[int, str]]]:
+        """拉取当前账号在两个赛道上的未解题 id、题目名以及题目方向（category）。
+
+        返回结构：
+        ```
+        {
+            REGULAR_TRACK: {"names": {cid: name}, "categories": {cid: category}},
+            ARENA_TRACK:   {"names": {cid: name}, "categories": {cid: category}},
+        }
+        ```
+        """
+        async with self._operation_session():
+            regular_ctx, arena_ctx = await asyncio.gather(
+                self._regular_context(), self._arena_context()
+            )
+            return {
+                REGULAR_TRACK: {
+                    "names": {
+                        cid: regular_ctx.challenge_names.get(cid, "")
+                        for cid in regular_ctx.challenge_ids
+                    },
+                    "categories": {
+                        cid: regular_ctx.challenge_categories.get(cid, "")
+                        for cid in regular_ctx.challenge_ids
+                    },
+                },
+                ARENA_TRACK: {
+                    "names": {
+                        cid: arena_ctx.challenge_names.get(cid, "")
+                        for cid in arena_ctx.challenge_ids
+                    },
+                    "categories": {
+                        cid: arena_ctx.challenge_categories.get(cid, "")
+                        for cid in arena_ctx.challenge_ids
+                    },
+                },
+            }
+
     async def _regular_context(self) -> ChallengeContext:
         html, challenge_ids = await asyncio.gather(
             self._request_text("GET", "/challenges", referer=f"{self.base_url}/"),
@@ -328,23 +416,25 @@ class ISCCClient:
         team_id = self._extract_team_id(html)
         solved_ids = await self._regular_solved_ids(team_id)
         unsolved_ids = sorted(challenge_ids - solved_ids)
-        challenge_names = await self._regular_challenge_names(unsolved_ids)
+        challenge_names, challenge_categories = await self._regular_challenge_details(unsolved_ids)
         return ChallengeContext(
             REGULAR_TRACK,
             TRACK_SUBMIT_PATH[REGULAR_TRACK],
             unsolved_ids,
             challenge_names,
+            challenge_categories,
         )
 
     async def _arena_context(self) -> ChallengeContext:
         challenge_ids, solved_ids = await asyncio.gather(self._arena_challenge_ids(), self._arena_solved_ids())
         unsolved_ids = sorted(challenge_ids - solved_ids)
-        challenge_names = await self._arena_challenge_names(unsolved_ids)
+        challenge_names, challenge_categories = await self._arena_challenge_details(unsolved_ids)
         return ChallengeContext(
             ARENA_TRACK,
             TRACK_SUBMIT_PATH[ARENA_TRACK],
             unsolved_ids,
             challenge_names,
+            challenge_categories,
         )
 
     async def _regular_solved_ids(self, team_id: str) -> set[int]:
@@ -363,7 +453,13 @@ class ISCCClient:
         return self._challenge_ids_from_payload(data)
 
     async def _regular_challenge_names(self, challenge_ids: list[int]) -> dict[int, str]:
-        return await self._fetch_challenge_names(
+        names, _ = await self._regular_challenge_details(challenge_ids)
+        return names
+
+    async def _regular_challenge_details(
+        self, challenge_ids: list[int]
+    ) -> tuple[dict[int, str], dict[int, str]]:
+        return await self._fetch_challenge_details(
             challenge_ids,
             detail_path="/chals/{id}",
             referer=f"{self.base_url}/challenges",
@@ -374,7 +470,13 @@ class ISCCClient:
         return self._challenge_ids_from_payload(data)
 
     async def _arena_challenge_names(self, challenge_ids: list[int]) -> dict[int, str]:
-        return await self._fetch_challenge_names(
+        names, _ = await self._arena_challenge_details(challenge_ids)
+        return names
+
+    async def _arena_challenge_details(
+        self, challenge_ids: list[int]
+    ) -> tuple[dict[int, str], dict[int, str]]:
+        return await self._fetch_challenge_details(
             challenge_ids,
             detail_path="/arenas/{id}",
             referer=f"{self.base_url}/arena",
@@ -386,7 +488,24 @@ class ISCCClient:
         detail_path: str,
         referer: str,
     ) -> dict[int, str]:
-        async def fetch_one(challenge_id: int) -> tuple[int, str]:
+        names, _ = await self._fetch_challenge_details(
+            challenge_ids, detail_path=detail_path, referer=referer
+        )
+        return names
+
+    async def _fetch_challenge_details(
+        self,
+        challenge_ids: list[int],
+        detail_path: str,
+        referer: str,
+    ) -> tuple[dict[int, str], dict[int, str]]:
+        """并发拉取 challenge 详情，返回 (names, categories) 两个 dict。
+
+        - 平台返回的 `category` 字段在不同部署里可能名为 `category`/`cat`/`tags`，
+          目前只取 `category`（ISCC 平台主流字段名）；取不到时返回空串。
+        - 任一请求失败时该题目仅保留可用字段，不影响其它题目。
+        """
+        async def fetch_one(challenge_id: int) -> tuple[int, str, str]:
             try:
                 data = await self._request_json(
                     "GET",
@@ -394,11 +513,20 @@ class ISCCClient:
                     referer=referer,
                 )
             except Exception:
-                return challenge_id, ""
-            return challenge_id, str(data.get("name") or "").strip()
+                return challenge_id, "", ""
+            name = str(data.get("name") or "").strip()
+            category = str(data.get("category") or data.get("cat") or "").strip()
+            return challenge_id, name, category
 
-        pairs = await asyncio.gather(*(fetch_one(cid) for cid in challenge_ids))
-        return {cid: name for cid, name in pairs if name}
+        triples = await asyncio.gather(*(fetch_one(cid) for cid in challenge_ids))
+        names: dict[int, str] = {}
+        categories: dict[int, str] = {}
+        for cid, name, category in triples:
+            if name:
+                names[cid] = name
+            if category:
+                categories[cid] = category
+        return names, categories
 
     @staticmethod
     def _challenge_ids_from_payload(data: dict) -> set[int]:


### PR DESCRIPTION
## Summary

- `ISCCSubmit` 模块新增对 `ISCC{xxxx} <方向>` 格式的识别：flag 主体后跟一个空格再跟方向 token（如 web、misc、reverse），表示该 flag 只批量提交到匹配该方向的未解题，方向匹配不区分大小写并支持子串模糊匹配。
- 与原有 `ISCC{xxxx}` 全量提交逻辑完全兼容，单条消息中"带方向"和"不带方向"的多个 flag 可以混排，会按出现顺序并发提交并去重。
- 题目方向 `category` 同步持久化到未解题缓存（新增 `categories` 列并附迁移），心跳刷新与 `iscc刷新` 均切换到包含 category 的明细接口。

## Changes

- `__init__.py`：扩展 `FLAG_PATTERN` 抓取方向 token，并加入负向先行断言避免把"下一条 flag"误吞为上一条 flag 的方向；`COMMANDS` 补充新格式说明。
- `handlers/iscc_client.py`：`ChallengeContext` 增加 `challenge_categories`；新增 `fetch_unsolved_challenges_detailed` 同时返回 name 与 category；`submit_flag(s)_to_unsolved` 增加 `prefetched_categories` 与 `category_filter` 入参，并提取 `_filter_by_category` 做大小写无关的子串过滤。
- `handlers/data_manager.py`：`iscc_unsolved_cache` 增加 `categories` 列并对老库做 `ALTER TABLE` 兼容；`save_unsolved_ids` / `remove_unsolved_ids` 同步维护方向映射；新增 `get_unsolved_categories`。
- `handlers/handle_message_private.py`：`_extract_flags` 改返 `(flag, category_filter)` 元组列表；`_resolve_unsolved_ids` / `_refresh_unsolved_cache` 同步落地 category；按方向提交但缓存缺 category 时主动补拉一次明细；回显信息按方向限定情况展示。
- `handlers/handle_meta_event.py`：心跳刷新缓存改用 detailed 接口，避免覆盖已有 category。

## Use Case

在 ISCC 平台未解题目较多的场景下：
- 旧逻辑：`ISCC{xxxx}` 会向所有未解题盲投，错误率高、易触发"提交过快"限制。
- 新逻辑：`ISCC{xxxx} web` 只命中 web 方向的未解题，大幅减少无效请求，提高效率并降低被限流的风险。

## Verification

- 本地 `python3 -m compileall app/modules/ISCCSubmit` 全部通过。
- 对 `_extract_flags` 用例覆盖：单 flag、带方向、混合多个 flag、紧邻两个 flag、HTML 实体、Tab 分隔等场景均符合预期。
- 兼容性：`fetch_unsolved_challenges` 与 `submit_flag(s)_to_unsolved` 的旧签名保留；数据库通过 `ALTER TABLE` 增量迁移，老数据可正常读取。